### PR TITLE
Add Laravel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # api-salesforce-integration
 A Salesforce integration package for garethhudson07/api
+
+## Laravel Integration
+
+The package ships with an optional Laravel service provider that handles
+authentication and caching of access tokens. Register the provider and publish
+the configuration file:
+
+```php
+// config/app.php
+'providers' => [
+    Oilstone\ApiSalesforceIntegration\Integrations\Laravel\ServiceProvider::class,
+],
+```
+
+```bash
+php artisan vendor:publish --tag=config --provider="Oilstone\\ApiSalesforceIntegration\\Integrations\\Laravel\\ServiceProvider"
+```
+
+The `config/salesforce-integration.php` file allows you to specify your
+Salesforce instance details and credentials:
+
+```php
+return [
+    'instance_url' => env('SALESFORCE_INSTANCE_URL'),
+    'instance_version' => env('SALESFORCE_INSTANCE_VERSION', 'v52.0'),
+    'client_id' => env('SALESFORCE_CLIENT_ID'),
+    'client_secret' => env('SALESFORCE_CLIENT_SECRET'),
+];
+```
+
+The service provider retrieves an access token using these values and caches it
+for subsequent requests using Laravel's cache facade.

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,13 @@
             "Oilstone\\ApiSalesforceIntegration\\": "src/"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Oilstone\\ApiSalesforceIntegration\\Integrations\\Laravel\\ServiceProvider"
+            ]
+        }
+    },
     "authors": [
         {
             "name": "Brendan Bullen",

--- a/src/Clients/Salesforce.php
+++ b/src/Clients/Salesforce.php
@@ -12,16 +12,19 @@ class Salesforce
 
     protected string $accessToken;
 
-    public function __construct(Client $httpClient, string $instanceUrl, string $accessToken)
+    protected string $instanceVersion;
+
+    public function __construct(Client $httpClient, string $instanceUrl, string $accessToken, string $instanceVersion = 'v52.0')
     {
         $this->httpClient = $httpClient;
         $this->instanceUrl = rtrim($instanceUrl, '/');
         $this->accessToken = $accessToken;
+        $this->instanceVersion = $instanceVersion;
     }
 
     public function query(string $soql): array
     {
-        $response = $this->httpClient->request('GET', $this->instanceUrl.'/services/data/v52.0/query', [
+        $response = $this->httpClient->request('GET', $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/query', [
             'headers' => [
                 'Authorization' => 'Bearer '.$this->accessToken,
                 'Accept' => 'application/json',

--- a/src/Integrations/Laravel/ServiceProvider.php
+++ b/src/Integrations/Laravel/ServiceProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration\Integrations\Laravel;
+
+use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use Oilstone\ApiSalesforceIntegration\Clients\Salesforce;
+
+class ServiceProvider extends BaseServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/config/salesforce-integration.php', 'salesforce-integration');
+
+        $this->app->singleton(Salesforce::class, function () {
+            $config = config('salesforce-integration');
+
+            $client = new Client();
+
+            $token = Cache::remember('salesforce.access_token', 55 * 60, function () use ($client, $config) {
+                $response = $client->post($config['instance_url'].'/services/oauth2/token', [
+                    'form_params' => [
+                        'grant_type' => 'client_credentials',
+                        'client_id' => $config['client_id'],
+                        'client_secret' => $config['client_secret'],
+                    ],
+                ]);
+
+                $data = json_decode((string) $response->getBody(), true);
+
+                return $data['access_token'] ?? null;
+            });
+
+            return new Salesforce($client, $config['instance_url'], $token, $config['instance_version']);
+        });
+    }
+
+    public function boot(): void
+    {
+        $this->publishes([
+            __DIR__.'/config/salesforce-integration.php' => config_path('salesforce-integration.php'),
+        ], 'config');
+    }
+}

--- a/src/Integrations/Laravel/config/salesforce-integration.php
+++ b/src/Integrations/Laravel/config/salesforce-integration.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'instance_url' => env('SALESFORCE_INSTANCE_URL'),
+    'instance_version' => env('SALESFORCE_INSTANCE_VERSION', 'v52.0'),
+    'client_id' => env('SALESFORCE_CLIENT_ID'),
+    'client_secret' => env('SALESFORCE_CLIENT_SECRET'),
+];


### PR DESCRIPTION
## Summary
- add Laravel service provider and config for Salesforce credentials
- make client API version configurable
- document Laravel integration details
- autoload Laravel provider via composer

## Testing
- `composer validate --no-check-all` *(fails: command not found)*
- `php -l src/Integrations/Laravel/ServiceProvider.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503f6960bc8325bd7da5ca150f793a