### PR TITLE
Add cacheable lookup helper and remove example lookup

### DIFF
--- a/src/Clients/Salesforce.php
+++ b/src/Clients/Salesforce.php
@@ -36,4 +36,29 @@ class Salesforce
 
         return $data['records'] ?? [];
     }
+
+    public function describe(string $object): array
+    {
+        $response = $this->httpClient->request('GET', $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/sobjects/'.trim($object, '/').'/describe', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$this->accessToken,
+                'Accept' => 'application/json',
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    public function picklistValues(string $object, string $field): array
+    {
+        $describe = $this->describe($object);
+
+        foreach ($describe['fields'] ?? [] as $fieldInfo) {
+            if (($fieldInfo['name'] ?? null) === $field && isset($fieldInfo['picklistValues'])) {
+                return array_values(array_map(fn ($v) => $v['value'], $fieldInfo['picklistValues']));
+            }
+        }
+
+        return [];
+    }
 }

--- a/src/Integrations/Laravel/CachedLookup.php
+++ b/src/Integrations/Laravel/CachedLookup.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration\Integrations\Laravel;
+
+use Illuminate\Support\Facades\Cache;
+use Oilstone\ApiSalesforceIntegration\Clients\Salesforce;
+use Oilstone\ApiSalesforceIntegration\Lookups\Lookup;
+
+abstract class CachedLookup extends Lookup
+{
+    /**
+     * Cache key for the lookup values.
+     */
+    protected static function cacheKey(): string
+    {
+        return 'salesforce.lookup.'.static::object().'.'.static::field();
+    }
+
+    /**
+     * Cache time to live in seconds.
+     */
+    protected static function ttl(): int
+    {
+        return 3600;
+    }
+
+    public static function all(?Salesforce $client = null): array
+    {
+        return Cache::remember(static::cacheKey(), static::ttl(), fn () => parent::all($client));
+    }
+}

--- a/src/Lookups/Lookup.php
+++ b/src/Lookups/Lookup.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration\Lookups;
+
+use Oilstone\ApiSalesforceIntegration\Clients\Salesforce;
+
+abstract class Lookup
+{
+    /**
+     * The Salesforce object name.
+     */
+    abstract public static function object(): string;
+
+    /**
+     * The field on the Salesforce object containing the picklist.
+     */
+    abstract public static function field(): string;
+
+    /**
+     * Retrieve all picklist values for the lookup.
+     */
+    public static function all(?Salesforce $client = null): array
+    {
+        $client = $client ?: (function_exists('app') ? app(Salesforce::class) : null);
+
+        if (! $client) {
+            throw new \InvalidArgumentException('Salesforce client must be provided.');
+        }
+
+        return $client->picklistValues(static::object(), static::field());
+    }
+}


### PR DESCRIPTION
## Summary
- remove the example `AccountSource` lookup
- add `CachedLookup` in the Laravel integration for cached picklist retrieval

## Testing
- `composer validate --no-check-all --strict` *(fails: command not found)*
- `php -l src/Integrations/Laravel/CachedLookup.php` *(fails: command not found)*
- `php -l src/Clients/Salesforce.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685137f132708325b62b7d4644579825