### PR TITLE
Update picklist lookup to use UI API

### DIFF
--- a/src/Clients/Salesforce.php
+++ b/src/Clients/Salesforce.php
@@ -49,16 +49,19 @@ class Salesforce
         return json_decode((string) $response->getBody(), true);
     }
 
-    public function picklistValues(string $object, string $field): array
+    public function picklistValues(string $object, string $recordTypeId, string $field): array
     {
-        $describe = $this->describe($object);
+        $response = $this->httpClient->request('GET',
+            $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/ui-api/object-info/'.trim($object, '/').'/picklist-values/'.trim($recordTypeId, '/').'/'.trim($field, '/'), [
+                'headers' => [
+                    'Authorization' => 'Bearer '.$this->accessToken,
+                    'Accept' => 'application/json',
+                ],
+            ]
+        );
 
-        foreach ($describe['fields'] ?? [] as $fieldInfo) {
-            if (($fieldInfo['name'] ?? null) === $field && isset($fieldInfo['picklistValues'])) {
-                return array_values(array_map(fn ($v) => $v['value'], $fieldInfo['picklistValues']));
-            }
-        }
+        $data = json_decode((string) $response->getBody(), true);
 
-        return [];
+        return array_values(array_map(fn ($v) => $v['value'], $data['values'] ?? []));
     }
 }

--- a/src/Integrations/Laravel/CachedLookup.php
+++ b/src/Integrations/Laravel/CachedLookup.php
@@ -15,7 +15,7 @@ abstract class CachedLookup extends Lookup
      */
     protected static function cacheKey(): string
     {
-        return 'salesforce.lookup.'.static::object().'.'.static::field();
+        return 'salesforce.lookup.'.static::object().'.'.static::recordTypeId().'.'.static::field();
     }
 
     /**

--- a/src/Lookups/Lookup.php
+++ b/src/Lookups/Lookup.php
@@ -17,10 +17,15 @@ abstract class Lookup
     abstract public static function field(): string;
 
     /**
+     * The record type id for the Salesforce object.
+     */
+    abstract public static function recordTypeId(): string;
+
+    /**
      * Retrieve all picklist values for the lookup.
      */
     public static function fetch(Salesforce $client): array
     {
-        return $client->picklistValues(static::object(), static::field());
+        return $client->picklistValues(static::object(), static::recordTypeId(), static::field());
     }
 }


### PR DESCRIPTION
## Summary
- switch picklistValues method to call UI API object-info endpoint
- expect a record type ID for lookups
- include record type ID in Laravel lookup cache keys

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685148ea6ec08325ba2861ec6565ea9d