### PR TITLE
Handle Salesforce attributes as record metadata

### DIFF
--- a/src/Integrations/Api/Transformers/Transformer.php
+++ b/src/Integrations/Api/Transformers/Transformer.php
@@ -25,6 +25,12 @@ class Transformer implements Contract
 
     public function transformMetaData(Record $record): array
     {
+        if (method_exists($record, 'getMetaData')) {
+            $meta = $record->getMetaData();
+
+            return is_array($meta) ? $meta : iterator_to_array($meta);
+        }
+
         return [];
     }
 

--- a/src/Record.php
+++ b/src/Record.php
@@ -8,9 +8,21 @@ use Oilstone\ApiSalesforceIntegration\Collection;
 
 class Record extends Map implements ApiRecordContract
 {
+    protected iterable $meta = [];
+
     public static function make(array $item): static
     {
         return (new static)->fill($item);
+    }
+
+    public function fill(array $attributes): static
+    {
+        if (array_key_exists('attributes', $attributes)) {
+            $this->meta = $attributes['attributes'];
+            unset($attributes['attributes']);
+        }
+
+        return parent::fill($attributes);
     }
 
     public function getRelations(): array
@@ -27,6 +39,18 @@ class Record extends Map implements ApiRecordContract
     public function getAttributes(): array
     {
         return $this->all();
+    }
+
+    public function getMetaData(): iterable
+    {
+        return $this->meta;
+    }
+
+    public function setMetaData(iterable $meta): static
+    {
+        $this->meta = $meta;
+
+        return $this;
     }
 
     public function getAttribute(string $key): mixed


### PR DESCRIPTION
## Summary
- treat Salesforce `attributes` field as metadata instead of normal attributes
- expose getter/setter for metadata on `Record`
- allow transformer to return record metadata

## Testing
- `php -v` *(fails: command not found)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851961ac8048325998b77e03f0dd6ab