### PR TITLE
Add repository default constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ return [
 
 The service provider retrieves an access token using these values and caches it
 for subsequent requests using Laravel's cache facade.
+
+## Repository constraints
+
+When creating a repository you may specify default constraints that are applied
+to every query. Constraints are provided as callbacks that receive the query
+builder instance:
+
+```php
+$resource->setObject('Account')
+    ->addConstraint(fn ($query) => $query->where('Type', 'Customer'))
+    ->addConstraint(fn ($query) => $query->where('RecordTypeId', '0123...'));
+```

--- a/src/Integrations/ApiResourceLoader/Resource.php
+++ b/src/Integrations/ApiResourceLoader/Resource.php
@@ -14,9 +14,15 @@ class Resource extends BaseResource
 {
     protected ?string $object;
 
+    /**
+     * @var array<int, callable>
+     */
+    protected array $constraints = [];
+
     public function repository(?Sentinel $sentinel = null): ?RepositoryContract
     {
-        return new Repository($this->object, $this->makeSchema(), $sentinel);
+        return (new Repository($this->object, $this->makeSchema(), $sentinel))
+            ->setDefaultConstraints($this->constraints);
     }
 
     public function transformer(BaseSchema $schema): ?TransformerContract
@@ -32,6 +38,24 @@ class Resource extends BaseResource
     public function setObject(?string $object): static
     {
         $this->object = $object;
+
+        return $this;
+    }
+
+    public function setConstraints(array $constraints): static
+    {
+        $this->constraints = [];
+
+        foreach ($constraints as $constraint) {
+            $this->addConstraint($constraint);
+        }
+
+        return $this;
+    }
+
+    public function addConstraint(callable $constraint): static
+    {
+        $this->constraints[] = $constraint;
 
         return $this;
     }


### PR DESCRIPTION
## Summary
- support defining default query constraints in Repository
- allow Resource classes to store constraint callbacks
- document how to add repository constraints

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519dbb3cd88325a62ebb1f65913e7b