### PR TITLE
Allow resources to define default constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,18 @@ $resource->setObject('Account')
     ->addConstraint(fn ($query) => $query->where('Type', 'Customer'))
     ->addConstraint(fn ($query) => $query->where('RecordTypeId', '0123...'));
 ```
+
+When extending the provided `Resource` class you may override the
+`constraints` method to declare default repository constraints:
+
+```php
+class University extends Resource
+{
+    protected ?string $object = 'Account';
+
+    protected function constraints(): array
+    {
+        return [fn ($query) => $query->where('Type', 'University')];
+    }
+}
+```

--- a/src/Integrations/ApiResourceLoader/Resource.php
+++ b/src/Integrations/ApiResourceLoader/Resource.php
@@ -19,11 +19,19 @@ class Resource extends BaseResource
      */
     protected array $constraints = [];
 
+    /**
+     * @return array<int, callable>
+     */
+    protected function constraints(): array
+    {
+        return [];
+    }
+
     public function repository(?Sentinel $sentinel = null): ?RepositoryContract
     {
         return (new Repository($this->object, $sentinel))
             ->setSchema($this->makeSchema())
-            ->setDefaultConstraints($this->constraints);
+            ->setDefaultConstraints(array_merge($this->constraints(), $this->constraints));
     }
 
     public function transformer(BaseSchema $schema): ?TransformerContract


### PR DESCRIPTION
## Summary
- enable `Resource` subclasses to specify default repository constraints by implementing `constraints()`
- document the new feature in the README

## Testing
- `php -l src/Integrations/ApiResourceLoader/Resource.php`
- `find src -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6851a1d17fc88325850df01360143c2c