### PR TITLE
Improve logging and Salesforce error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ return [
     'instance_version' => env('SALESFORCE_INSTANCE_VERSION', 'v52.0'),
     'client_id' => env('SALESFORCE_CLIENT_ID'),
     'client_secret' => env('SALESFORCE_CLIENT_SECRET'),
+    'debug' => env('SALESFORCE_DEBUG', false),
 ];
 ```
 
 The service provider retrieves an access token using these values and caches it
 for subsequent requests using Laravel's cache facade.
+
+When `SALESFORCE_DEBUG` is enabled the package will log each API request and
+its corresponding response using Laravel's logger.
+
+If a request results in an error response a `SalesforceException` will be
+thrown containing the decoded error details which can be retrieved using
+`getErrors()`.
 
 ## Repository constraints
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "garethhudson07/aggregate": "^1.2",
         "garethhudson07/api": "^9.5",
         "nesbot/carbon": "^3.10",
-        "guzzlehttp/guzzle": "^7.9"
+        "guzzlehttp/guzzle": "^7.9",
+        "psr/log": "^3.0"
     },
     "require-dev": {
         "laravel/framework": "^11.0",

--- a/src/Clients/Salesforce.php
+++ b/src/Clients/Salesforce.php
@@ -3,6 +3,9 @@
 namespace Oilstone\ApiSalesforceIntegration\Clients;
 
 use GuzzleHttp\Client;
+use Psr\Log\LoggerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Oilstone\ApiSalesforceIntegration\Exceptions\SalesforceException;
 
 class Salesforce
 {
@@ -14,17 +17,50 @@ class Salesforce
 
     protected string $instanceVersion;
 
-    public function __construct(Client $httpClient, string $instanceUrl, string $accessToken, string $instanceVersion = 'v52.0')
+    protected ?LoggerInterface $logger = null;
+
+    public function __construct(Client $httpClient, string $instanceUrl, string $accessToken, string $instanceVersion = 'v52.0', ?LoggerInterface $logger = null)
     {
         $this->httpClient = $httpClient;
         $this->instanceUrl = rtrim($instanceUrl, '/');
         $this->accessToken = $accessToken;
         $this->instanceVersion = $instanceVersion;
+        $this->logger = $logger;
+    }
+
+    protected function log(string $method, string $url, array $context, array $response, int $status): void
+    {
+        if (! $this->logger) {
+            return;
+        }
+
+        $this->logger->debug('Salesforce request', array_merge($context, [
+            'method' => $method,
+            'url' => $url,
+            'status' => $status,
+            'response' => $response,
+        ]));
+    }
+
+    protected function request(string $method, string $url, array $options): array
+    {
+        $response = $this->httpClient->request($method, $url, $options);
+
+        $body = (string) $response->getBody();
+        $data = json_decode($body, true);
+
+        $this->log($method, $url, $options['query'] ?? [], $data, $response->getStatusCode());
+
+        if ($response->getStatusCode() >= 400) {
+            throw SalesforceException::fromResponse($response);
+        }
+
+        return $data ?? [];
     }
 
     public function query(string $soql): array
     {
-        $response = $this->httpClient->request('GET', $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/query', [
+        $data = $this->request('GET', $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/query', [
             'headers' => [
                 'Authorization' => 'Bearer '.$this->accessToken,
                 'Accept' => 'application/json',
@@ -32,35 +68,33 @@ class Salesforce
             'query' => ['q' => $soql],
         ]);
 
-        $data = json_decode((string) $response->getBody(), true);
-
         return $data['records'] ?? [];
     }
 
     public function describe(string $object): array
     {
-        $response = $this->httpClient->request('GET', $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/sobjects/'.trim($object, '/').'/describe', [
+        $url = $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/sobjects/'.trim($object, '/').'/describe';
+
+        $data = $this->request('GET', $url, [
             'headers' => [
                 'Authorization' => 'Bearer '.$this->accessToken,
                 'Accept' => 'application/json',
             ],
         ]);
 
-        return json_decode((string) $response->getBody(), true);
+        return $data;
     }
 
     public function picklistValues(string $object, string $recordTypeId, string $field): array
     {
-        $response = $this->httpClient->request('GET',
-            $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/ui-api/object-info/'.trim($object, '/').'/picklist-values/'.trim($recordTypeId, '/').'/'.trim($field, '/'), [
-                'headers' => [
-                    'Authorization' => 'Bearer '.$this->accessToken,
-                    'Accept' => 'application/json',
-                ],
-            ]
-        );
+        $url = $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/ui-api/object-info/'.trim($object, '/').'/picklist-values/'.trim($recordTypeId, '/').'/'.trim($field, '/');
 
-        $data = json_decode((string) $response->getBody(), true);
+        $data = $this->request('GET', $url, [
+            'headers' => [
+                'Authorization' => 'Bearer '.$this->accessToken,
+                'Accept' => 'application/json',
+            ],
+        ]);
 
         return array_values(array_map(
             fn ($v) => html_entity_decode($v['value'], ENT_QUOTES | ENT_HTML5),

--- a/src/Exceptions/SalesforceException.php
+++ b/src/Exceptions/SalesforceException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration\Exceptions;
+
+use Psr\Http\Message\ResponseInterface;
+
+class SalesforceException extends Exception
+{
+    protected array $errors = [];
+
+    public function __construct(array $errors, int $code)
+    {
+        parent::__construct($errors[0]['message'] ?? 'Salesforce error', $code);
+        $this->errors = $errors;
+    }
+
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    public static function fromResponse(ResponseInterface $response): self
+    {
+        $data = json_decode((string) $response->getBody(), true) ?: [];
+        $errors = isset($data[0]) ? $data : [$data];
+
+        return new self($errors, $response->getStatusCode());
+    }
+}

--- a/src/Integrations/Laravel/ServiceProvider.php
+++ b/src/Integrations/Laravel/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Oilstone\ApiSalesforceIntegration\Integrations\Laravel;
 
 use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Oilstone\ApiSalesforceIntegration\Clients\Salesforce;
 
@@ -32,7 +33,13 @@ class ServiceProvider extends BaseServiceProvider
                 return $data['access_token'] ?? null;
             });
 
-            return new Salesforce($client, $config['instance_url'], $token, $config['instance_version']);
+            $logger = null;
+
+            if (! empty($config['debug'])) {
+                $logger = Log::channel();
+            }
+
+            return new Salesforce($client, $config['instance_url'], $token, $config['instance_version'], $logger);
         });
     }
 

--- a/src/Integrations/Laravel/config/salesforce.php
+++ b/src/Integrations/Laravel/config/salesforce.php
@@ -5,4 +5,5 @@ return [
     'instance_version' => env('SALESFORCE_INSTANCE_VERSION', 'v62.0'),
     'client_id' => env('SALESFORCE_CLIENT_ID'),
     'client_secret' => env('SALESFORCE_CLIENT_SECRET'),
+    'debug' => env('SALESFORCE_DEBUG', false),
 ];


### PR DESCRIPTION
## Summary
- add `SalesforceException` to expose API error details
- centralize HTTP request logic in Salesforce client
- log decoded responses when debug mode is enabled
- document new exception handling

## Testing
- `composer validate --no-check-publish` *(fails: composer not found)*
- `php -v` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a7d6b5ec8325bbfd6733ce3b12bf