### PR TITLE
Split repository into base and API specific classes

### DIFF
--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration;
+
+use Oilstone\ApiSalesforceIntegration\Clients\Salesforce;
+
+class BaseRepository
+{
+    protected ?string $object;
+
+    /**
+     * @var array<int, callable>
+     */
+    protected array $defaultConstraints = [];
+
+    public function __construct(?string $object = null)
+    {
+        $this->object = $object;
+    }
+
+    public function setDefaultConstraints(array $constraints): static
+    {
+        $this->defaultConstraints = [];
+
+        foreach ($constraints as $constraint) {
+            $this->addDefaultConstraint($constraint);
+        }
+
+        return $this;
+    }
+
+    public function addDefaultConstraint(callable $constraint): static
+    {
+        $this->defaultConstraints[] = $constraint;
+
+        return $this;
+    }
+
+    protected function getClient(): Salesforce
+    {
+        return app(Salesforce::class);
+    }
+
+    protected function newQuery(?string $object = null): Query
+    {
+        $query = new Query($object ?? $this->object, $this->getClient());
+
+        foreach ($this->defaultConstraints as $constraint) {
+            $constraint($query);
+        }
+
+        return $query;
+    }
+}

--- a/src/Integrations/ApiResourceLoader/Resource.php
+++ b/src/Integrations/ApiResourceLoader/Resource.php
@@ -7,7 +7,7 @@ use Api\Repositories\Contracts\Resource as RepositoryContract;
 use Api\Schema\Schema as BaseSchema;
 use Api\Transformers\Contracts\Transformer as TransformerContract;
 use Oilstone\ApiSalesforceIntegration\Integrations\Api\Transformers\Transformer;
-use Oilstone\ApiSalesforceIntegration\Repository;
+use Oilstone\ApiSalesforceIntegration\Integrations\Api\Repository;
 use Oilstone\ApiResourceLoader\Resources\Resource as BaseResource;
 
 class Resource extends BaseResource


### PR DESCRIPTION
## Summary
- create `BaseRepository` with no API dependencies
- move previous repository to `Integrations/Api` and extend the base class
- update resource loader to use the new API repository
- exclude schema from `BaseRepository` and keep default field logic in API repository

## Testing
- `php -l src/BaseRepository.php`
- `php -l src/Integrations/Api/Repository.php`
- `php -l src/Integrations/ApiResourceLoader/Resource.php`


------
https://chatgpt.com/codex/tasks/task_e_6853d1946ad88325bb89fdbcd1d63db8