### PR TITLE
Add query options and CRUD functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,33 @@ class University extends Resource
     }
 }
 ```
+
+## Repository queries
+
+The `find`, `first` and `get` methods accept an optional array of options that
+can be used to build the underlying query. Available options are:
+
+- `conditions` – an array of where constraints (arrays or callbacks)
+- `select` – fields to return
+- `includes` – relationships to include
+- `order` – sorting definitions
+- `limit` and `offset` – for pagination
+
+```php
+$repo->get([
+    'select' => ['Id', 'Name'],
+    'includes' => ['Contacts'],
+    'conditions' => [['Type', 'Customer']],
+    'order' => [['Name', 'ASC']],
+    'limit' => 10,
+    'offset' => 20,
+]);
+```
+
+The repository also supports simple write operations:
+
+```php
+$record = $repo->create(['Name' => 'New Account']);
+$repo->update($record['id'], ['Name' => 'Updated']);
+$repo->delete($record['id']);
+```

--- a/src/Clients/Salesforce.php
+++ b/src/Clients/Salesforce.php
@@ -101,4 +101,44 @@ class Salesforce
             $data['values'] ?? []
         ));
     }
+
+    public function create(string $object, array $payload): array
+    {
+        $url = $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/sobjects/'.trim($object, '/');
+
+        return $this->request('POST', $url, [
+            'headers' => [
+                'Authorization' => 'Bearer '.$this->accessToken,
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ],
+            'json' => $payload,
+        ]);
+    }
+
+    public function update(string $object, string $id, array $payload): array
+    {
+        $url = $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/sobjects/'.trim($object, '/').'/'.trim($id, '/');
+
+        return $this->request('PATCH', $url, [
+            'headers' => [
+                'Authorization' => 'Bearer '.$this->accessToken,
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ],
+            'json' => $payload,
+        ]);
+    }
+
+    public function delete(string $object, string $id): array
+    {
+        $url = $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/sobjects/'.trim($object, '/').'/'.trim($id, '/');
+
+        return $this->request('DELETE', $url, [
+            'headers' => [
+                'Authorization' => 'Bearer '.$this->accessToken,
+                'Accept' => 'application/json',
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary
- allow repository methods to accept options for selecting, filtering, sorting and pagination
- document query options and CRUD usage
- add create, update and delete methods for Salesforce client and repository

## Testing
- `php -l src/Clients/Salesforce.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e1735aec83259fc10500ae5d5385