### PR TITLE
Add relationship includes support

### DIFF
--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -23,6 +23,8 @@ class Repository implements RepositoryInterface
 
     protected array $defaultConstraints = [];
 
+    protected array $defaultIncludes = [];
+
     public function __construct(
         protected string $object,
     ) {}
@@ -54,6 +56,13 @@ class Repository implements RepositoryInterface
     public function setDefaultConstraints(array $constraints): static
     {
         $this->defaultConstraints = $constraints;
+
+        return $this;
+    }
+
+    public function setDefaultIncludes(array $includes): static
+    {
+        $this->defaultIncludes = $includes;
 
         return $this;
     }
@@ -104,7 +113,7 @@ class Repository implements RepositoryInterface
 
     protected function newQuery(?string $object = null): Query
     {
-        return (new BaseRepository($object ?? $this->object, $this->defaultConstraints))->newQuery();
+        return (new BaseRepository($object ?? $this->object, $this->defaultConstraints, $this->defaultIncludes))->newQuery();
     }
 
     protected function getDefaultFields(): array

--- a/src/Integrations/ApiResourceLoader/Resource.php
+++ b/src/Integrations/ApiResourceLoader/Resource.php
@@ -13,6 +13,8 @@ class Resource extends BaseResource
 
     protected array $constraints = [];
 
+    protected array $includes = [];
+
     protected ?string $transformer = Transformer::class;
 
     protected ?string $repository = Repository::class;
@@ -29,7 +31,8 @@ class Resource extends BaseResource
         $repository = (new $repositoryClass($this->object))
             ->setSchema($schema)
             ->setTransformer($this->makeTransformer($schema))
-            ->setDefaultConstraints(array_merge($this->constraints(), $this->constraints));
+            ->setDefaultConstraints(array_merge($this->constraints(), $this->constraints))
+            ->setDefaultIncludes(array_merge($this->includes(), $this->includes));
 
         if (method_exists($repository, 'setSentinel')) {
             $repository->setSentinel($sentinel);
@@ -60,6 +63,18 @@ class Resource extends BaseResource
     public function setConstraints(array $constraints): static
     {
         $this->constraints = $constraints;
+
+        return $this;
+    }
+
+    public function includes(): array
+    {
+        return $this->includes;
+    }
+
+    public function setIncludes(array $includes): static
+    {
+        $this->includes = $includes;
 
         return $this;
     }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -9,11 +9,19 @@ class Repository
     public function __construct(
         protected string $object,
         protected array $defaultConstraints = [],
+        protected array $defaultIncludes = [],
     ) {}
 
     public function setDefaultConstraints(array $constraints): static
     {
         $this->defaultConstraints = $constraints;
+
+        return $this;
+    }
+
+    public function setDefaultIncludes(array $includes): static
+    {
+        $this->defaultIncludes = $includes;
 
         return $this;
     }
@@ -34,6 +42,10 @@ class Repository
             }
 
             $query->where($constraint);
+        }
+
+        foreach ($this->defaultIncludes as $include) {
+            $query->with($include);
         }
 
         return $query;


### PR DESCRIPTION
## Summary
- allow repositories to store default relationship includes
- pass default includes through API integration repository
- support includes setting in API Resource

## Testing
- `php -l src/Repository.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2522ae508325bb7fcfe55a2da2ab