### PR TITLE
Implement Salesforce query caching

### DIFF
--- a/src/Cache/QueryCacheHandler.php
+++ b/src/Cache/QueryCacheHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+class QueryCacheHandler
+{
+    protected string $prefix = 'salesforce.query.';
+
+    public function __construct(
+        protected CacheInterface $cache,
+        protected ?int $ttl = null
+    ) {}
+
+    public function setTtl(?int $ttl): static
+    {
+        $this->ttl = $ttl;
+        return $this;
+    }
+
+    public function remember(string $soql, callable $callback): array
+    {
+        $key = $this->prefix.md5($soql);
+
+        if ($this->cache->has($key)) {
+            $value = $this->cache->get($key);
+            if (is_array($value)) {
+                return $value;
+            }
+        }
+
+        $data = $callback();
+
+        $this->cache->set($key, $data, $this->ttl);
+
+        return $data;
+    }
+}

--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -25,6 +25,8 @@ class Repository implements RepositoryInterface
 
     protected array $defaultIncludes = [];
 
+    protected ?\Oilstone\ApiSalesforceIntegration\Cache\QueryCacheHandler $cacheHandler = null;
+
     public function __construct(
         protected string $object,
     ) {}
@@ -63,6 +65,13 @@ class Repository implements RepositoryInterface
     public function setDefaultIncludes(array $includes): static
     {
         $this->defaultIncludes = $includes;
+
+        return $this;
+    }
+
+    public function setCacheHandler(\Oilstone\ApiSalesforceIntegration\Cache\QueryCacheHandler $handler): static
+    {
+        $this->cacheHandler = $handler;
 
         return $this;
     }
@@ -113,7 +122,13 @@ class Repository implements RepositoryInterface
 
     protected function newQuery(?string $object = null): Query
     {
-        return (new BaseRepository($object ?? $this->object, $this->defaultConstraints, $this->defaultIncludes))->newQuery();
+        $base = new BaseRepository($object ?? $this->object, $this->defaultConstraints, $this->defaultIncludes, $this->cacheHandler);
+
+        if ($this->cacheHandler) {
+            $base->setCacheHandler($this->cacheHandler);
+        }
+
+        return $base->newQuery();
     }
 
     protected function getDefaultFields(): array

--- a/src/Integrations/Laravel/ServiceProvider.php
+++ b/src/Integrations/Laravel/ServiceProvider.php
@@ -7,12 +7,19 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Oilstone\ApiSalesforceIntegration\Clients\Salesforce;
+use Oilstone\ApiSalesforceIntegration\Cache\QueryCacheHandler;
 
 class ServiceProvider extends BaseServiceProvider
 {
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/config/salesforce.php', 'salesforce');
+
+        $this->app->singleton(QueryCacheHandler::class, function ($app) {
+            $cache = $app->make('cache.psr6');
+
+            return new QueryCacheHandler($cache);
+        });
 
         $this->app->singleton(Salesforce::class, function () {
             $config = config('salesforce');

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -10,6 +10,7 @@ class Repository
         protected string $object,
         protected array $defaultConstraints = [],
         protected array $defaultIncludes = [],
+        protected ?\Oilstone\ApiSalesforceIntegration\Cache\QueryCacheHandler $cacheHandler = null,
     ) {}
 
     public function setDefaultConstraints(array $constraints): static
@@ -26,9 +27,20 @@ class Repository
         return $this;
     }
 
+    public function setCacheHandler(\Oilstone\ApiSalesforceIntegration\Cache\QueryCacheHandler $handler): static
+    {
+        $this->cacheHandler = $handler;
+
+        return $this;
+    }
+
     public function newQuery(?string $object = null): Query
     {
         $query = new Query($object ?? $this->object, $this->getClient());
+
+        if ($this->cacheHandler) {
+            $query->setCacheHandler($this->cacheHandler);
+        }
 
         foreach ($this->defaultConstraints as $constraint) {
             if (is_array($constraint)) {


### PR DESCRIPTION
## Summary
- add QueryCacheHandler to provide a PSR-16 based cache helper
- allow Query to use an injected cache handler
- support cache handler injection in Repository classes
- expose per-resource TTL and configure repository cache in the ApiResourceLoader integration
- register a default cache handler with the Laravel service provider

## Testing
- `php -l src/Cache/QueryCacheHandler.php`
- `php -l src/Query.php`
- `php -l src/Repository.php`
- `php -l src/Integrations/Api/Repository.php`
- `php -l src/Integrations/ApiResourceLoader/Resource.php`
- `php -l src/Integrations/Laravel/ServiceProvider.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_686ba3e1686483259392fca6b1d690bf