### PR TITLE
Fix cache interface in ServiceProvider

### DIFF
--- a/src/Integrations/Laravel/ServiceProvider.php
+++ b/src/Integrations/Laravel/ServiceProvider.php
@@ -18,7 +18,7 @@ class ServiceProvider extends BaseServiceProvider
         $config = config('salesforce');
 
         $this->app->singleton(QueryCacheHandler::class, function ($app) use ($config) {
-            $cache = $app->make('cache.psr6');
+            $cache = $app->make('cache.psr16');
 
             return new QueryCacheHandler($cache, $config['query_cache_default_ttl']);
         });


### PR DESCRIPTION
## Summary
- fix ServiceProvider to use `cache.psr16` instead of PSR-6 cache

## Testing
- `composer validate --no-check-all --no-check-publish` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bac01ff2883259f7d53b5e53a6750