### PR TITLE
Add cache tagging and Artisan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ php artisan vendor:publish --tag=config --provider="Oilstone\\ApiSalesforceInteg
 
 Configure your Salesforce instance in `config/salesforce.php` and the provider will handle authentication and caching of access tokens. When the `debug` option is enabled each request and response is logged via Laravel's logger.
 
+If the cache store supports tagging, query results are tagged by the Salesforce object name and, for `find` queries, the record ID. You can clear cached results using the provided Artisan command:
+
+```bash
+php artisan salesforce:cache:clear Account
+php artisan salesforce:cache:clear Account 001XXXXXXXXXXXXXXX
+```
+
 ## Basic usage
 
 ### Stand‑alone

--- a/src/Integrations/Laravel/Console/ClearCache.php
+++ b/src/Integrations/Laravel/Console/ClearCache.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration\Integrations\Laravel\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Contracts\Cache\TaggableStore;
+
+class ClearCache extends Command
+{
+    protected $signature = 'salesforce:cache:clear {resource} {id?}';
+
+    protected $description = 'Clear Salesforce query cache by tag';
+
+    public function handle(): int
+    {
+        $resource = $this->argument('resource');
+        $id = $this->argument('id');
+
+        $store = Cache::store();
+
+        if (! method_exists($store, 'tags') || ! ($store->getStore() instanceof TaggableStore)) {
+            $this->error('Cache store does not support tagging.');
+            return 1;
+        }
+
+        $tags = [$resource];
+        if ($id) {
+            $tags[] = $resource . ':' . $id;
+        }
+
+        Cache::tags($tags)->flush();
+
+        $this->info('Cache cleared for: ' . implode(', ', $tags));
+
+        return 0;
+    }
+}

--- a/src/Integrations/Laravel/ServiceProvider.php
+++ b/src/Integrations/Laravel/ServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Oilstone\ApiSalesforceIntegration\Cache\QueryCacheHandler;
 use Oilstone\ApiSalesforceIntegration\Clients\Salesforce;
+use Oilstone\ApiSalesforceIntegration\Integrations\Laravel\Console\ClearCache;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -55,5 +56,11 @@ class ServiceProvider extends BaseServiceProvider
         $this->publishes([
             __DIR__.'/config/salesforce.php' => config_path('salesforce.php'),
         ], 'config');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ClearCache::class,
+            ]);
+        }
     }
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -30,6 +30,8 @@ class Query
 
     protected ?QueryCacheHandler $cacheHandler = null;
 
+    protected array $cacheTags = [];
+
     public function __construct(string $object, Salesforce $client)
     {
         $this->object = $object;
@@ -41,6 +43,18 @@ class Query
         $this->cacheHandler = $handler;
 
         return $this;
+    }
+
+    public function setCacheTags(array $tags): static
+    {
+        $this->cacheTags = $tags;
+
+        return $this;
+    }
+
+    public function getCacheTags(): array
+    {
+        return $this->cacheTags;
     }
 
     public static function make(string $object, Salesforce $client): static
@@ -258,7 +272,7 @@ class Query
         $callback = fn () => $this->client->query($soql);
 
         $results = $this->cacheHandler
-            ? $this->cacheHandler->remember($soql, $callback)
+            ? $this->cacheHandler->remember($soql, $callback, $this->cacheTags)
             : $callback();
 
         return (new Set)->fill(array_map(

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -49,6 +49,7 @@ class Repository
 
         if ($this->cacheHandler) {
             $query->setCacheHandler($this->cacheHandler);
+            $query->setCacheTags([$object ?? $this->object]);
         }
 
         foreach ($this->defaultConstraints as $constraint) {
@@ -115,8 +116,12 @@ class Repository
     public function find(string $id, array $options = []): ?Record
     {
         $options['select'] = $options['select'] ?? ['FIELDS(ALL)'];
+        $query = $this->newQuery()->where('Id', $id);
+        if ($this->cacheHandler) {
+            $query->setCacheTags([$this->object, $this->object.':'.$id]);
+        }
 
-        return $this->applyOptions($this->newQuery()->where('Id', $id), $options)->first();
+        return $this->applyOptions($query, $options)->first();
     }
 
     public function first(array $options = []): ?Record


### PR DESCRIPTION
## Summary
- tag cache entries with Salesforce object and optionally record ID when supported
- expose tags via `Query` and set automatically in `Repository`
- add `salesforce:cache:clear` Artisan command
- register command in the service provider
- document cache tags and command usage

## Testing
- `composer validate --strict`
- `composer install` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bd16c522083258c3fea6ccd740391