### PR TITLE
Implement Salesforce update in API repository

### DIFF
--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -107,28 +107,58 @@ class Repository implements RepositoryInterface
 
     public function create(Pipe $pipe, ServerRequestInterface $request): ResultRecordInterface
     {
-        throw new MethodNotAllowedException;
+        $object = $request->getQueryParams()['object'] ?? null;
+
+        $attributes = $pipe->getResource()->getTransformer()->reverse(
+            $request->getParsedBody()->toArray()
+        );
+
+        $result = $this->repository($object)->create($attributes);
+
+        return $this->repository($object)->find($result['id']);
     }
 
     public function update(Pipe $pipe, ServerRequestInterface $request): ResultRecordInterface
     {
-        throw new MethodNotAllowedException;
+        $object = $request->getQueryParams()['object'] ?? null;
+
+        $fields = $pipe->getResource()->getTransformer()->reverse(
+            $request->getParsedBody()->toArray()
+        );
+
+        $this->repository($object)->update($pipe->getKey(), $fields);
+
+        return $this->getByKey($pipe);
     }
 
     public function delete(Pipe $pipe): ResultRecordInterface
     {
-        throw new MethodNotAllowedException;
+        $record = $this->getByKey($pipe);
+
+        $this->repository()->delete($pipe->getKey());
+
+        return $record;
     }
 
     protected function newQuery(?string $object = null): Query
     {
-        $base = new BaseRepository($object ?? $this->object, $this->defaultConstraints, $this->defaultIncludes, $this->cacheHandler);
+        return $this->repository($object)->newQuery();
+    }
+
+    protected function repository(?string $object = null): BaseRepository
+    {
+        $repository = new BaseRepository(
+            $object ?? $this->object,
+            $this->defaultConstraints,
+            $this->defaultIncludes,
+            $this->cacheHandler
+        );
 
         if ($this->cacheHandler) {
-            $base->setCacheHandler($this->cacheHandler);
+            $repository->setCacheHandler($this->cacheHandler);
         }
 
-        return $base->newQuery();
+        return $repository;
     }
 
     /**

--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -9,7 +9,6 @@ use Api\Result\Contracts\Record as ResultRecordInterface;
 use Api\Schema\Schema;
 use Api\Transformers\Contracts\Transformer;
 use Oilstone\ApiSalesforceIntegration\Collection;
-use Oilstone\ApiSalesforceIntegration\Exceptions\MethodNotAllowedException;
 use Oilstone\ApiSalesforceIntegration\Integrations\Api\Bridge\QueryResolver;
 use Oilstone\ApiSalesforceIntegration\Query;
 use Oilstone\ApiSalesforceIntegration\Repository as BaseRepository;
@@ -153,10 +152,6 @@ class Repository implements RepositoryInterface
             $this->defaultIncludes,
             $this->cacheHandler
         );
-
-        if ($this->cacheHandler) {
-            $repository->setCacheHandler($this->cacheHandler);
-        }
 
         return $repository;
     }


### PR DESCRIPTION
## Summary
- implement the update method for the API integration repository to send updates to Salesforce and return the updated record via getByKey
- implement create and delete methods using shared repository helper

## Testing
- `composer validate --strict`
- `php -l src/Integrations/Api/Repository.php`


------
https://chatgpt.com/codex/tasks/task_e_6876289e91bc83259aca6b333054a7d2