### PR TITLE
Ensure repository clears cache on update/delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ php artisan salesforce:cache:clear Account
 php artisan salesforce:cache:clear Account 001XXXXXXXXXXXXXXX
 ```
 
+Cached results for a specific record are automatically cleared when the
+repository's `update` or `delete` methods are used with a configured
+`QueryCacheHandler`. Only the tag for that particular record is flushed so
+cached queries for other records remain intact.
+
 ## Basic usage
 
 ### Stand‑alone

--- a/src/Cache/QueryCacheHandler.php
+++ b/src/Cache/QueryCacheHandler.php
@@ -44,4 +44,20 @@ class QueryCacheHandler
 
         return $data;
     }
+
+    /**
+     * Flush cached queries associated with the provided tags.
+     */
+    public function flush(array $tags): void
+    {
+        $cache = $this->cache;
+
+        if ($tags && method_exists($cache, 'tags') && method_exists($cache, 'getStore')) {
+            $store = $cache->getStore();
+
+            if ($store instanceof \Illuminate\Cache\TaggableStore) {
+                $cache->tags($tags)->flush();
+            }
+        }
+    }
 }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -145,12 +145,24 @@ class Repository
 
     public function update(string $id, array $attributes): array
     {
-        return $this->getClient()->update($this->object, $id, $attributes);
+        $result = $this->getClient()->update($this->object, $id, $attributes);
+
+        if ($this->cacheHandler) {
+            $this->cacheHandler->flush([$this->object.':'.$id]);
+        }
+
+        return $result;
     }
 
     public function delete(string $id): array
     {
-        return $this->getClient()->delete($this->object, $id);
+        $result = $this->getClient()->delete($this->object, $id);
+
+        if ($this->cacheHandler) {
+            $this->cacheHandler->flush([$this->object.':'.$id]);
+        }
+
+        return $result;
     }
 
     protected function getClient(): Salesforce


### PR DESCRIPTION
## Summary
- add ability to flush tags from `QueryCacheHandler`
- clear cached queries in `Repository::update` and `Repository::delete`
- document automatic cache clearing
- only flush cache entries for a single record instead of the whole object

## Testing
- `composer install --no-interaction`
- `php -l src/Cache/QueryCacheHandler.php`
- `php -l src/Repository.php`
- `php -l README.md`


------
https://chatgpt.com/codex/tasks/task_e_687647aed6108325b87ebda692f071f3