### PR TITLE
Add cache tag support for single-record queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ php artisan vendor:publish --tag=config --provider="Oilstone\\ApiSalesforceInteg
 
 Configure your Salesforce instance in `config/salesforce.php` and the provider will handle authentication and caching of access tokens. When the `debug` option is enabled each request and response is logged via Laravel's logger.
 
-If the cache store supports tagging, query results are tagged by the Salesforce object name and, for `find` queries, the record ID. You can clear cached results using the provided Artisan command:
+If the cache store supports tagging, query results are tagged by the Salesforce object name and, for single-record queries such as `find`, `getByKey` or `getRecord`, the record ID. You can clear cached results using the provided Artisan command:
 
 ```bash
 php artisan salesforce:cache:clear Account

--- a/src/Integrations/Api/Bridge/QueryResolver.php
+++ b/src/Integrations/Api/Bridge/QueryResolver.php
@@ -18,7 +18,16 @@ class QueryResolver
 
     public function byKey(): ?Record
     {
-        return (new Query($this->keyedQuery()))->select($this->defaultFields ?: ['FIELDS(ALL)'])->first();
+        $query = $this->keyedQuery();
+
+        $query->setCacheTags([
+            $query->getObject(),
+            $query->getObject() . ':' . $this->pipe->getKey(),
+        ]);
+
+        return (new Query($query))
+            ->select($this->defaultFields ?: ['FIELDS(ALL)'])
+            ->first();
     }
 
     public function record(ServerRequestInterface $request): ?Record


### PR DESCRIPTION
## Summary
- ensure single record lookups tag cache with record ID
- add cache tags to QueryResolver when retrieving by key
- document the behaviour around caching single records

## Testing
- `composer install --no-interaction`
- `php -l src/Integrations/Api/Repository.php`
- `php -l src/Integrations/Api/Bridge/QueryResolver.php`


------
https://chatgpt.com/codex/tasks/task_e_6876650a12c08325bf7f0132366f592b