### PR TITLE
Update address line meta handling

### DIFF
--- a/src/Integrations/Api/Transformers/Transformer.php
+++ b/src/Integrations/Api/Transformers/Transformer.php
@@ -4,6 +4,7 @@ namespace Oilstone\ApiSalesforceIntegration\Integrations\Api\Transformers;
 
 use Api\Result\Contracts\Record;
 use Api\Schema\Schema;
+use Api\Schema\Property as SchemaProperty;
 use Api\Transformers\Contracts\Transformer as Contract;
 use Carbon\Carbon;
 
@@ -87,11 +88,10 @@ class Transformer implements Contract
             }
 
             if ($property->hasMeta('isAddressLine')) {
+                $line = (int) $property->isAddressLine;
                 $lines = preg_split('/\r\n|\n|\r/', (string) $value);
 
-                for ($i = 1; $i <= 3; $i++) {
-                    $transformed[$property->getName() . $i] = ($lines[$i - 1] ?? null) ?: null;
-                }
+                $transformed[$property->getName()] = ($lines[$line - 1] ?? null) ?: null;
 
                 continue;
             }
@@ -105,6 +105,7 @@ class Transformer implements Contract
     protected function reverseSchema(Schema $schema, array $attributes): array
     {
         $reversed = [];
+        $addressLines = [];
 
         foreach ($schema->getProperties() as $property) {
             if ($property->hasMeta('readonly') || $property->hasMeta('validationOnly')) {
@@ -124,24 +125,24 @@ class Transformer implements Contract
             $key = $property->alias ?: $property->getName();
 
             if ($property->hasMeta('isAddressLine')) {
-                $lines = [];
+                $line = (int) $property->isAddressLine;
+                $lineValue = $attributes[$property->getName()] ?? null;
 
-                for ($i = 1; $i <= 3; $i++) {
-                    $lineKey = $property->getName() . $i;
-
-                    if (array_key_exists($lineKey, $attributes)) {
-                        $lines[] = $attributes[$lineKey];
-                    }
+                if ($lineValue === null && array_key_exists($key, $attributes)) {
+                    $lines = preg_split('/\r\n|\n|\r/', (string) $attributes[$key]);
+                    $lineValue = $lines[$line - 1] ?? null;
                 }
 
-                if (empty($lines) && array_key_exists($property->getName(), $attributes)) {
-                    $lines = preg_split('/\r\n|\n|\r/', (string) $attributes[$property->getName()]);
+                if (! isset($addressLines[$key])) {
+                    $addressLines[$key] = ['property' => $property, 'lines' => []];
                 }
 
-                $value = trim(implode("\n", array_filter($lines, fn($line) => $line !== null && $line !== ''))) ?: null;
-            } else {
-                $value = $attributes[$property->getName()] ?? null;
+                $addressLines[$key]['lines'][$line] = $lineValue;
+
+                continue;
             }
+
+            $value = $attributes[$property->getName()] ?? null;
 
             if ($property->hasMeta('isYesNo') && $value !== null) {
                 $value = $value ? 'Yes' : 'No';
@@ -167,6 +168,53 @@ class Transformer implements Contract
             }
 
             $path = explode('.', $key);
+            $current = &$reversed;
+
+            while (count($path) > 1) {
+                $segment = array_shift($path);
+
+                if (! isset($current[$segment]) || ! is_array($current[$segment])) {
+                    $current[$segment] = [];
+                }
+
+                $current = &$current[$segment];
+            }
+
+            $current[$path[0]] = $value;
+        }
+
+        foreach ($addressLines as $alias => $data) {
+            /** @var SchemaProperty $prop */
+            $prop = $data['property'];
+            $lines = $data['lines'];
+
+            if (array_key_exists($alias, $attributes) && is_string($attributes[$alias])) {
+                $value = $attributes[$alias];
+            } else {
+                ksort($lines);
+                $value = trim(implode("\n", array_filter($lines, fn($line) => $line !== null && $line !== ''))) ?: null;
+            }
+
+            if ($value) {
+                switch ($prop->getType()) {
+                    case 'date':
+                        $value = Carbon::parse($value)->toDateString();
+                        break;
+
+                    case 'datetime':
+                    case 'timestamp':
+                        $value = Carbon::parse($value)->toDateTimeString();
+                        break;
+
+                    case 'collection':
+                        $value = array_values(array_filter(array_map(function ($item) use ($prop) {
+                            return $item ? $this->reverseSchema($prop->getAccepts(), $item) : null;
+                        }, $value)));
+                        break;
+                }
+            }
+
+            $path = explode('.', $alias);
             $current = &$reversed;
 
             while (count($path) > 1) {


### PR DESCRIPTION
## Summary
- handle `isAddressLine` meta as a numbered line
- collapse numbered address lines back into a single field when reversing

## Testing
- `php -l src/Integrations/Api/Transformers/Transformer.php`
- `find src -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68779463279c8325b37cdb398c7d820e