### PR TITLE
Add repository helper methods and magic call

### DIFF
--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -164,6 +164,21 @@ class Repository implements RepositoryInterface
         );
     }
 
+    public function __call(string $method, array $parameters)
+    {
+        $repository = $this->repository();
+
+        if (method_exists($repository, $method)) {
+            return $repository->{$method}(...$parameters);
+        }
+
+        throw new \BadMethodCallException(sprintf(
+            'Method %s::%s does not exist.',
+            static::class,
+            $method
+        ));
+    }
+
     /**
      * Gets the default fields from the schema, including nested schema properties.
      *

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -165,6 +165,50 @@ class Repository
         return $result;
     }
 
+    public function getById(string $id, array $options = []): ?Record
+    {
+        return $this->find($id, $options);
+    }
+
+    public function firstOrCreate(array $attributes, array $extra = []): Record
+    {
+        $query = $this->newQuery();
+
+        foreach ($attributes as $field => $value) {
+            $query->where($field, $value);
+        }
+
+        $record = $this->applyOptions($query, ['select' => ['FIELDS(ALL)']])->first();
+
+        if ($record) {
+            return $record;
+        }
+
+        $result = $this->create(array_merge($attributes, $extra));
+
+        return $this->find($result['id']);
+    }
+
+    public function updateOrCreate(array $attributes, array $values = []): Record
+    {
+        $query = $this->newQuery();
+
+        foreach ($attributes as $field => $value) {
+            $query->where($field, $value);
+        }
+
+        $record = $this->applyOptions($query, ['select' => ['Id']])->first();
+
+        if ($record) {
+            $this->update($record['Id'], $values);
+            return $this->find($record['Id']);
+        }
+
+        $result = $this->create(array_merge($attributes, $values));
+
+        return $this->find($result['id']);
+    }
+
     protected function getClient(): Salesforce
     {
         return $this->client ?? app(Salesforce::class);


### PR DESCRIPTION
## Summary
- allow API integration repository to proxy unknown method calls to the base repository
- add `getById`, `firstOrCreate`, and `updateOrCreate` helpers on the base repository

## Testing
- `composer install --no-interaction`
- `php -l src/Repository.php`
- `php -l src/Integrations/Api/Repository.php`


------
https://chatgpt.com/codex/tasks/task_e_687f6b524a7883258a6a01c3f18f34f7