### PR TITLE
Add configurable identifier support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ use Oilstone\ApiSalesforceIntegration\Integrations\Api\Repository as ApiReposito
 class AccountRepository extends ApiRepository
 {
     protected string $object = 'Account';
+    // Optionally customise the identifier column
+    protected string $identifier = 'External_Id__c';
 }
 ```
 

--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -27,6 +27,8 @@ class Repository implements RepositoryInterface
 
     protected ?QueryCacheHandler $cacheHandler = null;
 
+    protected string $identifier = 'Id';
+
     public function __construct(
         protected string $object,
     ) {}
@@ -74,6 +76,18 @@ class Repository implements RepositoryInterface
         $this->cacheHandler = $handler;
 
         return $this;
+    }
+
+    public function setIdentifier(string $identifier): static
+    {
+        $this->identifier = $identifier;
+
+        return $this;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
     }
 
     public function getByKey(Pipe $pipe): ?ResultRecordInterface
@@ -156,12 +170,12 @@ class Repository implements RepositoryInterface
 
     protected function repository(?string $object = null): BaseRepository
     {
-        return new BaseRepository(
+        return (new BaseRepository(
             $object ?? $this->object,
             $this->defaultConstraints,
             $this->defaultIncludes,
             $this->cacheHandler
-        );
+        ))->setIdentifier($this->identifier);
     }
 
     public function __call(string $method, array $parameters)

--- a/src/Integrations/ApiResourceLoader/Resource.php
+++ b/src/Integrations/ApiResourceLoader/Resource.php
@@ -16,6 +16,8 @@ class Resource extends BaseResource
 
     protected array $includes = [];
 
+    protected string $identifier = 'Id';
+
     protected ?string $transformer = Transformer::class;
 
     protected ?string $repository = Repository::class;
@@ -49,7 +51,8 @@ class Resource extends BaseResource
             ->setSchema($schema)
             ->setTransformer($this->makeTransformer($schema))
             ->setDefaultConstraints(array_merge($this->constraints(), $this->constraints))
-            ->setDefaultIncludes(array_merge($this->includes(), $this->includes));
+            ->setDefaultIncludes(array_merge($this->includes(), $this->includes))
+            ->setIdentifier($this->identifier);
 
         if (method_exists($repository, 'setCacheHandler') && $this->cacheHandler) {
             $handler = clone $this->cacheHandler;
@@ -102,6 +105,18 @@ class Resource extends BaseResource
     public function setIncludes(array $includes): static
     {
         $this->includes = $includes;
+
+        return $this;
+    }
+
+    public function identifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function setIdentifier(string $identifier): static
+    {
+        $this->identifier = $identifier;
 
         return $this;
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -14,7 +14,9 @@ class Query
 
     protected Salesforce $client;
 
-    protected array $selects = ['Id'];
+    protected string $identifier;
+
+    protected array $selects = [];
 
     protected array $relationships = [];
 
@@ -32,10 +34,12 @@ class Query
 
     protected array $cacheTags = [];
 
-    public function __construct(string $object, Salesforce $client)
+    public function __construct(string $object, Salesforce $client, string $identifier = 'Id')
     {
         $this->object = $object;
         $this->client = $client;
+        $this->identifier = $identifier;
+        $this->selects = [$identifier];
     }
 
     public function setCacheHandler(QueryCacheHandler $handler): static
@@ -57,9 +61,9 @@ class Query
         return $this->cacheTags;
     }
 
-    public static function make(string $object, Salesforce $client): static
+    public static function make(string $object, Salesforce $client, string $identifier = 'Id'): static
     {
-        return new static($object, $client);
+        return new static($object, $client, $identifier);
     }
 
     public function getObject(): ?string
@@ -70,6 +74,18 @@ class Query
     public function setObject(string $object): static
     {
         $this->object = $object;
+
+        return $this;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function setIdentifier(string $identifier): static
+    {
+        $this->identifier = $identifier;
 
         return $this;
     }
@@ -116,7 +132,7 @@ class Query
         }, explode(',', $fields)));
 
         if (! $fieldList) {
-            $fieldList = ['Id', 'Name'];
+            $fieldList = [$this->identifier, 'Name'];
         }
 
         if ($prefix) {
@@ -290,7 +306,7 @@ class Query
 
     protected function toSoql(): string
     {
-        $select = implode(', ', array_merge($this->selects ?: ['Id'], $this->relationships));
+        $select = implode(', ', array_merge($this->selects ?: [$this->identifier], $this->relationships));
         $query = "SELECT {$select} FROM {$this->object}";
 
         if ($this->conditions) {


### PR DESCRIPTION
## Summary
- add identifier configuration for API and base repositories
- allow resources to define default identifier
- support identifier in query builder
- document identifier usage in README

## Testing
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_687f74ad97248325a6fdddcc98a69115