### PR TITLE
Fix missing logs for failing Salesforce queries

### DIFF
--- a/src/Clients/Salesforce.php
+++ b/src/Clients/Salesforce.php
@@ -49,6 +49,9 @@ class Salesforce
                 'Authorization' => 'Bearer '.$this->accessToken,
                 'Accept' => 'application/json',
             ],
+            // Prevent Guzzle from throwing exceptions so we can log errors
+            // and convert them to SalesforceException consistently.
+            'http_errors' => false,
         ], $options));
 
         $body = (string) $response->getBody();


### PR DESCRIPTION
## Summary
- ensure Guzzle doesn't throw HTTP errors so requests are always logged

## Testing
- `composer validate --strict`
- `composer install --prefer-dist --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_6880d788487c83258cc28e3fbd739302