### PR TITLE
Implement caching of Salesforce object descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ repository's `update` or `delete` methods are used with a configured
 `QueryCacheHandler`. Only the tag for that particular record is flushed so
 cached queries for other records remain intact.
 
+Object descriptions fetched via the client are also cached through the same
+handler, preventing repetitive calls to Salesforce's `describe` endpoint.
+
 ## Basic usage
 
 ### Stand‑alone

--- a/src/Query.php
+++ b/src/Query.php
@@ -20,7 +20,6 @@ class Query
 
     protected array $relationships = [];
 
-    protected static array $descriptions = [];
 
     protected array $conditions = [];
 
@@ -163,11 +162,7 @@ class Query
 
     protected function describe(string $object): array
     {
-        if (! array_key_exists($object, self::$descriptions)) {
-            self::$descriptions[$object] = $this->client->describe($object);
-        }
-
-        return self::$descriptions[$object];
+        return $this->client->describe($object);
     }
 
     public function select(array|string $columns): static

--- a/src/Record.php
+++ b/src/Record.php
@@ -11,7 +11,6 @@ class Record extends Map implements ApiRecordContract
 {
     protected iterable $meta = [];
 
-    protected static array $descriptions = [];
 
     protected static ?Salesforce $client = null;
 
@@ -133,10 +132,6 @@ class Record extends Map implements ApiRecordContract
     {
         $client = self::$client ?? app(Salesforce::class);
 
-        if (! array_key_exists($object, self::$descriptions)) {
-            self::$descriptions[$object] = $client->describe($object);
-        }
-
-        return self::$descriptions[$object];
+        return $client->describe($object);
     }
 }


### PR DESCRIPTION
## Summary
- add QueryCacheHandler support to the client and cache describe responses
- remove in-memory describe caches from Query and Record
- document caching of descriptions in README

## Testing
- `composer validate --strict`
- `php -l src/Clients/Salesforce.php`
- `php -l src/Query.php`
- `php -l src/Record.php`


------
https://chatgpt.com/codex/tasks/task_e_6880febe59e08325b9a8b61c78a47fbb