### PR TITLE
Add logger support to query cache handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If your project uses Laravel you can register the service provider and publish t
 php artisan vendor:publish --tag=config --provider="Oilstone\\ApiSalesforceIntegration\\Integrations\\Laravel\\ServiceProvider"
 ```
 
-Configure your Salesforce instance in `config/salesforce.php` and the provider will handle authentication and caching of access tokens. When the `debug` option is enabled each request and response is logged via Laravel's logger.
+Configure your Salesforce instance in `config/salesforce.php` and the provider will handle authentication and caching of access tokens. When the `debug` option is enabled each request and response is logged via Laravel's logger. Queries served from the cache are also logged with a `cache` flag so they can be distinguished from live requests.
 
 If the cache store supports tagging, query results are tagged by the Salesforce object name and, for single-record queries such as `find`, `getByKey` or `getRecord`, the record ID. You can clear cached results using the provided Artisan command:
 

--- a/src/Integrations/Laravel/ServiceProvider.php
+++ b/src/Integrations/Laravel/ServiceProvider.php
@@ -20,8 +20,9 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->app->singleton(QueryCacheHandler::class, function ($app) use ($config) {
             $cache = $app->make('cache.store');
+            $logger = ! empty($config['debug']) ? Log::channel() : null;
 
-            return new QueryCacheHandler($cache, $config['query_cache_default_ttl']);
+            return new QueryCacheHandler($cache, $config['query_cache_default_ttl'], $logger);
         });
 
         $this->app->singleton(Salesforce::class, function () use ($config) {


### PR DESCRIPTION
## Summary
- allow QueryCacheHandler to accept a logger and log cache hits
- pass the logger from Laravel service provider
- document cache logging behaviour

## Testing
- `composer install`
- `composer dump-autoload -o`
- `php -l src/Cache/QueryCacheHandler.php`
- `php -l src/Integrations/Laravel/ServiceProvider.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_6881075da8508325a83d205b8fbf4a28