### PR TITLE
Implement delimited meta in transformer

### DIFF
--- a/src/Integrations/Api/Transformers/Transformer.php
+++ b/src/Integrations/Api/Transformers/Transformer.php
@@ -82,6 +82,10 @@ class Transformer implements Contract
                 }
             }
 
+            if ($property->hasMeta('delimited') && $value !== null && ! is_array($value)) {
+                $value = $value === '' ? [] : explode($property->delimited, (string) $value);
+            }
+
             if ($property->hasMeta('isYesNo')) {
                 $value = $value !== null ? strtolower((string) $value) === 'yes' : null;
             }
@@ -164,6 +168,10 @@ class Transformer implements Contract
                         }, $value)));
                         break;
                 }
+            }
+
+            if ($property->hasMeta('delimited') && is_array($value)) {
+                $value = implode($property->delimited, $value);
             }
 
             $path = explode('.', $key);


### PR DESCRIPTION
## Summary
- support `delimited` meta property in Transformer so values can be exploded and imploded

## Testing
- `composer validate --strict`
- `composer install --prefer-dist --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_688115c3fcb88325a63e9f6202b3b65e