### PR TITLE
Handle `needs` metadata when extracting schema fields

### DIFF
--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -417,6 +417,14 @@ class Repository implements RepositoryInterface
                 $fieldName = $property->alias ?: $property->getName();
                 $fields[] = $prefix . $fieldName;
             }
+
+            if ($property->hasMeta('needs')) {
+                $needs = is_array($property->needs) ? $property->needs : [$property->needs];
+
+                foreach ($needs as $need) {
+                    $fields[] = $prefix . $need;
+                }
+            }
         }
 
         return $fields;


### PR DESCRIPTION
## Summary
- include meta `needs` when generating default fields

## Testing
- `composer validate --no-check-all --strict`
- `php -l src/Integrations/Api/Repository.php`

------
https://chatgpt.com/codex/tasks/task_e_6883b3875e248325875b248098121afe