### PR TITLE
Fix attribute handling in sfFirstOrCreate

### DIFF
--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -343,7 +343,19 @@ class Repository implements RepositoryInterface
     protected function reverseAttributes(array $attributes, bool $allowNull = false): array
     {
         if ($this->transformer) {
-            $attributes = $this->transformer->reverse($attributes);
+            $transformed = $this->transformer->reverse($attributes);
+
+            $known = [];
+
+            if ($this->schema) {
+                foreach ($this->schema->getProperties() as $property) {
+                    $known[] = $property->getName();
+                }
+            }
+
+            $unknown = array_diff_key($attributes, array_flip($known));
+
+            $attributes = array_replace($unknown, $transformed);
         }
 
         return $allowNull ? $attributes : array_filter($attributes, fn ($value) => isset($value));

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -356,7 +356,7 @@ class Repository
                 continue;
             }
 
-            if ($value === null && ! $attributeExists) {
+            if (($value === null || $value === '') && ! $attributeExists) {
                 unset($payload[$key]);
             }
         }


### PR DESCRIPTION
## Summary
- keep unrecognised fields when transforming attributes
- drop empty string defaults from repository payloads

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_688a4a00b1088325aa8db049ea1bf217