### PR TITLE
Fix query defaults usage

### DIFF
--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -340,10 +340,10 @@ class Repository implements RepositoryInterface
     /**
      * Reverse transform only the provided attributes.
      */
-    protected function reverseAttributes(array $attributes, bool $allowNull = false): array
+    protected function reverseAttributes(array $attributes, bool $allowNull = false, bool $ignoreFixed = false): array
     {
         if ($this->transformer) {
-            $transformed = $this->transformer->reverse($attributes);
+            $transformed = $this->transformer->reverse($attributes, $ignoreFixed);
 
             $known = [];
 
@@ -366,7 +366,7 @@ class Repository implements RepositoryInterface
      */
     protected function reverseConditions(array $conditions): array
     {
-        return $conditions ? $this->reverseAttributes($conditions) : [];
+        return $conditions ? $this->reverseAttributes($conditions, false, true) : [];
     }
 
     protected function newQuery(?string $object = null): Query


### PR DESCRIPTION
## Summary
- stop applying fixed schema defaults when reversing conditions
- allow ignoring fixed values in Reverse transformer

## Testing
- `composer install`
- `php -l src/Integrations/Api/Transformers/Transformer.php`
- `php -l src/Integrations/Api/Repository.php`


------
https://chatgpt.com/codex/tasks/task_e_688a4cec01e48325b00816a36739509a