### PR TITLE
Fix token caching behavior

### DIFF
--- a/src/Integrations/Laravel/ServiceProvider.php
+++ b/src/Integrations/Laravel/ServiceProvider.php
@@ -39,7 +39,11 @@ class ServiceProvider extends BaseServiceProvider
 
                 $data = json_decode((string) $response->getBody(), true);
 
-                return $data['access_token'] ?? null;
+                if (! isset($data['access_token'])) {
+                    throw new \RuntimeException('Unable to retrieve Salesforce access token.');
+                }
+
+                return $data['access_token'];
             });
 
             $queryCacheHandler = $this->app->make(QueryCacheHandler::class);


### PR DESCRIPTION
## Summary
- return token from Salesforce login only when present
- throw `RuntimeException` if token not returned

## Testing
- `composer validate --strict`

------
https://chatgpt.com/codex/tasks/task_e_688b3a87c7f88325af2cb0d4fad55de7