### PR TITLE
Add count method

### DIFF
--- a/src/Clients/Salesforce.php
+++ b/src/Clients/Salesforce.php
@@ -69,9 +69,21 @@ class Salesforce
         return $data ?? [];
     }
 
+    /**
+     * Perform a SOQL query and return the raw response.
+     */
+    public function rawQuery(string $soql): array
+    {
+        return $this->request(
+            'GET',
+            $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/query',
+            ['query' => ['q' => $soql], 'log_request' => true],
+        );
+    }
+
     public function query(string $soql): array
     {
-        return $this->request('GET', $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/query', ['query' => ['q' => $soql], 'log_request' => true])['records'] ?? [];
+        return $this->rawQuery($soql)['records'] ?? [];
     }
 
     public function describe(string $object): array

--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -275,6 +275,16 @@ class Repository implements RepositoryInterface
     }
 
     /**
+     * Proxy the count method on the underlying repository.
+     */
+    public function sfCount(array $conditions = [], array $options = [], ?string $object = null): int
+    {
+        $conditions = $this->reverseConditions($conditions);
+
+        return $this->repository($object)->count($conditions, $options);
+    }
+
+    /**
      * Proxy the first method on the underlying repository with optional
      * transformation of the returned record.
      */

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -242,6 +242,38 @@ class Repository
         return $this->applyOptions($query, $options)->get();
     }
 
+    /**
+     * Count the number of records that match the given conditions.
+     */
+    public function count(array $conditionsOrOptions = [], array $options = []): int
+    {
+        if ($options === [] && $this->isOptionsArray($conditionsOrOptions)) {
+            $options = $conditionsOrOptions;
+            $conditions = [];
+        } else {
+            $conditions = $conditionsOrOptions;
+        }
+
+        $query = $this->newQuery();
+
+        foreach ($conditions as $field => $value) {
+            $query->where($field, $value);
+        }
+
+        foreach ($options['conditions'] ?? [] as $condition) {
+            if (is_callable($condition)) {
+                $condition($query);
+                continue;
+            }
+
+            if (is_array($condition)) {
+                $query->where(...$condition);
+            }
+        }
+
+        return $query->count();
+    }
+
     public function create(array $attributes): array
     {
         $payload = array_replace_recursive($this->defaultValues, $attributes);


### PR DESCRIPTION
## Summary
- support rawQuery in Salesforce client
- add count method to Query builder
- add count method to Repository classes

## Testing
- `composer install`
- `composer dump-autoload`
- `find src -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_688b42f7f6a88325a6dfb7461fc7584c