### PR TITLE
Fix count with default includes

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -305,11 +305,15 @@ class Query
     public function count(): int
     {
         $originalSelects = $this->selects;
+        $originalRelationships = $this->relationships;
+
         $this->selects = ['COUNT()'];
+        $this->relationships = [];
 
         $soql = $this->toSoql();
 
         $this->selects = $originalSelects;
+        $this->relationships = $originalRelationships;
 
         $callback = fn () => $this->client->rawQuery($soql);
 


### PR DESCRIPTION
## Summary
- ensure `Query::count()` doesn't include relationships

## Testing
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_688b461967b48325869833fc2fee68f7