### PR TITLE
Fix cache tag clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ php artisan vendor:publish --tag=config --provider="Oilstone\\ApiSalesforceInteg
 
 Configure your Salesforce instance in `config/salesforce.php` and the provider will handle authentication and caching of access tokens. When the `debug` option is enabled each request and response is logged via Laravel's logger. Queries served from the cache are also logged with a `cache` flag so they can be distinguished from live requests.
 
-If the cache store supports tagging, query results are tagged by the Salesforce object name and, for single-record queries such as `find`, `getByKey` or `getRecord`, the record ID. You can clear cached results using the provided Artisan command:
+If the cache store supports tagging, query results are tagged by the Salesforce object name. Collection queries receive an additional `<object>:findMany` tag while single-record queries are tagged with `<object>:findOne`. When fetching by ID the record tag `<object>:<id>` is also applied. You can clear cached results using the provided Artisan command:
 
 ```bash
 php artisan salesforce:cache:clear Account
@@ -46,8 +46,9 @@ php artisan salesforce:cache:clear Account 001XXXXXXXXXXXXXXX
 
 Cached results for a specific record are automatically cleared when the
 repository's `update` or `delete` methods are used with a configured
-`QueryCacheHandler`. Only the tag for that particular record is flushed so
-cached queries for other records remain intact.
+`QueryCacheHandler`. The record tag `<object>:<id>` and any list caches tagged
+with `<object>:findMany` are flushed so collection results stay in sync. Newly
+created records trigger only the `<object>:findMany` flush.
 
 Object descriptions fetched via the client are also cached through the same
 handler, preventing repetitive calls to Salesforce's `describe` endpoint.

--- a/src/Integrations/Api/Bridge/QueryResolver.php
+++ b/src/Integrations/Api/Bridge/QueryResolver.php
@@ -23,6 +23,7 @@ class QueryResolver
         $query->setCacheTags([
             $query->getObject(),
             $query->getObject() . ':' . $this->pipe->getKey(),
+            $query->getObject() . ':findOne',
         ]);
 
         return (new Query($query))

--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -124,6 +124,7 @@ class Repository implements RepositoryInterface
         $query->setCacheTags([
             $object ?? $this->object,
             ($object ?? $this->object) . ':' . $pipe->getKey(),
+            ($object ?? $this->object) . ':findOne',
         ]);
 
         return (new QueryResolver(

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -82,7 +82,10 @@ class Repository
 
         if ($this->cacheHandler) {
             $query->setCacheHandler($this->cacheHandler);
-            $query->setCacheTags([$object ?? $this->object]);
+            $query->setCacheTags([
+                $object ?? $this->object,
+                ($object ?? $this->object) . ':findMany',
+            ]);
         }
 
         foreach ($this->defaultConstraints as $constraint) {
@@ -169,7 +172,11 @@ class Repository
             $query->where($this->defaultIdentifier, $id);
 
             if ($this->cacheHandler) {
-                $query->setCacheTags([$this->object, $this->object.':'.$id]);
+                $query->setCacheTags([
+                    $this->object,
+                    $this->object.':'.$id,
+                    $this->object.':findOne',
+                ]);
             }
         }
 
@@ -282,7 +289,9 @@ class Repository
         $result = $this->getClient()->create($this->object, $payload);
 
         if ($this->cacheHandler) {
-            $this->cacheHandler->flush([$this->object]);
+            $this->cacheHandler->flush([
+                $this->object . ':findMany',
+            ]);
         }
 
         return array_merge($payload, $result ?? []);
@@ -296,7 +305,10 @@ class Repository
         $result = $this->getClient()->update($this->object, $id, $payload);
 
         if ($this->cacheHandler) {
-            $this->cacheHandler->flush([$this->object.':'.$id]);
+            $this->cacheHandler->flush([
+                $this->object . ':findMany',
+                $this->object . ':' . $id,
+            ]);
         }
 
         return array_merge($payload, [$this->defaultIdentifier => $id], $result ?? []);
@@ -307,7 +319,10 @@ class Repository
         $result = $this->getClient()->delete($this->object, $id);
 
         if ($this->cacheHandler) {
-            $this->cacheHandler->flush([$this->object.':'.$id]);
+            $this->cacheHandler->flush([
+                $this->object . ':findMany',
+                $this->object . ':' . $id,
+            ]);
         }
 
         return $result;


### PR DESCRIPTION
## Summary
- tag record queries with both object and record tags so console commands clear them
- refine caching by tagging queries with `:findOne` or `:findMany`
- flush only list and record caches on updates

## Testing
- `composer install --no-interaction`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_688b4f39796c8325a85438bc97ed5580