### PR TITLE
Fix sfCreate with custom identifier

### DIFF
--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -143,7 +143,9 @@ class Repository implements RepositoryInterface
 
         $result = $repository->create($fields);
 
-        return Record::make($repository->findOrFail($result['id'])->toArray());
+        $record = $repository->findOrFail(['Id' => $result['id']]);
+
+        return Record::make($record->toArray());
     }
 
     public function update(Pipe $pipe, ServerRequestInterface $request): ResultRecordInterface
@@ -178,7 +180,13 @@ class Repository implements RepositoryInterface
 
         $result = $this->repository($object)->create($fields);
 
-        return $this->sfFindOrFail($result['id'], [], $object);
+        $record = $this->repository($object)->findOrFail(['Id' => $result['id']], [
+            'select' => $this->getDefaultFields(),
+        ]);
+
+        return $this->transformer
+            ? $this->transformer->transform($record)
+            : $record->getAttributes();
     }
 
     /**

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -349,7 +349,7 @@ class Repository
 
         $result = $this->create(array_merge($attributes, $extra));
 
-        return $this->findOrFail($result['id']);
+        return $this->findOrFail(['Id' => $result['id']]);
     }
 
     public function updateOrCreate(array $attributes, array $values = []): Record
@@ -369,7 +369,7 @@ class Repository
 
         $result = $this->create(array_merge($attributes, $values));
 
-        return $this->findOrFail($result['id']);
+        return $this->findOrFail(['Id' => $result['id']]);
     }
 
     protected function isOptionsArray(array $data): bool


### PR DESCRIPTION
## Summary
- after creating records, fetch them using Salesforce `Id` to support custom repository identifiers

## Testing
- `composer validate --strict`
- `composer install --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_688ccf54565c8325b2f890e9acad3b5a