### PR TITLE
Refactor repository for array-only results

### DIFF
--- a/src/Integrations/Api/Bridge/Query.php
+++ b/src/Integrations/Api/Bridge/Query.php
@@ -2,12 +2,12 @@
 
 namespace Oilstone\ApiSalesforceIntegration\Integrations\Api\Bridge;
 
-use Aggregate\Set;
 use Api\Queries\Expression;
 use Api\Queries\Paths\Path;
 use Api\Queries\Relations as RequestRelations;
 use Oilstone\ApiSalesforceIntegration\Query as SalesforceQuery;
-use Oilstone\ApiSalesforceIntegration\Record;
+use Oilstone\ApiSalesforceIntegration\Integrations\Api\Results\Collection;
+use Oilstone\ApiSalesforceIntegration\Integrations\Api\Results\Record;
 use Carbon\Carbon;
 
 class Query
@@ -31,14 +31,16 @@ class Query
         return $this->baseQuery;
     }
 
-    public function get(): Set
+    public function get(): Collection
     {
-        return $this->baseQuery->get();
+        return Collection::make($this->baseQuery->get());
     }
 
     public function first(): ?Record
     {
-        return $this->baseQuery->first();
+        $result = $this->baseQuery->first();
+
+        return $result ? Record::make($result) : null;
     }
 
     public function include(RequestRelations $relations): self

--- a/src/Integrations/Api/Bridge/QueryResolver.php
+++ b/src/Integrations/Api/Bridge/QueryResolver.php
@@ -2,10 +2,10 @@
 
 namespace Oilstone\ApiSalesforceIntegration\Integrations\Api\Bridge;
 
-use Aggregate\Set;
 use Api\Pipeline\Pipes\Pipe;
 use Oilstone\ApiSalesforceIntegration\Query as QueryBuilder;
-use Oilstone\ApiSalesforceIntegration\Record;
+use Oilstone\ApiSalesforceIntegration\Integrations\Api\Results\Collection;
+use Oilstone\ApiSalesforceIntegration\Integrations\Api\Results\Record;
 use Psr\Http\Message\ServerRequestInterface;
 
 class QueryResolver
@@ -36,7 +36,7 @@ class QueryResolver
         return $this->resolve($this->keyedQuery($request->getQueryParams()['key'] ?? null), $request)->first();
     }
 
-    public function collection(ServerRequestInterface $request): Set
+    public function collection(ServerRequestInterface $request): Collection
     {
         return $this->resolve($this->baseQuery(), $request)->get();
     }

--- a/src/Integrations/Api/Results/Collection.php
+++ b/src/Integrations/Api/Results/Collection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Oilstone\ApiSalesforceIntegration;
+namespace Oilstone\ApiSalesforceIntegration\Integrations\Api\Results;
 
 use Aggregate\Set;
 use Api\Result\Contracts\Collection as Contract;

--- a/src/Integrations/Api/Results/Record.php
+++ b/src/Integrations/Api/Results/Record.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Oilstone\ApiSalesforceIntegration;
+namespace Oilstone\ApiSalesforceIntegration\Integrations\Api\Results;
 
 use Aggregate\Map;
 use Api\Result\Contracts\Record as ApiRecordContract;
-use Oilstone\ApiSalesforceIntegration\Collection;
+use Oilstone\ApiSalesforceIntegration\Integrations\Api\Results\Collection;
 use Oilstone\ApiSalesforceIntegration\Clients\Salesforce;
 
 class Record extends Map implements ApiRecordContract

--- a/src/Query.php
+++ b/src/Query.php
@@ -2,7 +2,6 @@
 
 namespace Oilstone\ApiSalesforceIntegration;
 
-use Aggregate\Set;
 use Api\Exceptions\InvalidQueryArgumentsException;
 use Api\Exceptions\UnknownOperatorException;
 use Oilstone\ApiSalesforceIntegration\Cache\QueryCacheHandler;
@@ -276,7 +275,7 @@ class Query
         return $this;
     }
 
-    public function get(): Set
+    public function get(): array
     {
         $soql = $this->toSoql();
 
@@ -286,17 +285,14 @@ class Query
             ? $this->cacheHandler->remember($soql, $callback, $this->cacheTags, ['log_request' => true])
             : $callback();
 
-        return (new Set)->fill(array_map(
-            fn (array $item) => (new Record)->fill($item),
-            $results
-        ));
+        return $results;
     }
 
-    public function first(): ?Record
+    public function first(): ?array
     {
         $result = $this->limit(1)->get();
 
-        return $result->count() ? $result[0] : null;
+        return $result[0] ?? null;
     }
 
     /**
@@ -325,10 +321,10 @@ class Query
         $values = [];
 
         foreach ($results as $record) {
-            $value = $record instanceof Record ? $record->get($column) : $record[$column] ?? null;
+            $value = $record[$column] ?? null;
 
             if ($index) {
-                $key = $record instanceof Record ? $record->get($index) : $record[$index] ?? null;
+                $key = $record[$index] ?? null;
                 $values[$key] = $value;
             } else {
                 $values[] = $value;

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -149,7 +149,7 @@ class Repository
         return $query;
     }
 
-    public function find(string|array $idConditionsOrOptions, array $options = []): ?Record
+    public function find(string|array $idConditionsOrOptions, array $options = []): ?array
     {
         $query = $this->newQuery();
 
@@ -187,7 +187,7 @@ class Repository
         return $this->applyOptions($query, $options)->first();
     }
 
-    public function findOrFail(string|array $idConditionsOrOptions, array $options = []): Record
+    public function findOrFail(string|array $idConditionsOrOptions, array $options = []): array
     {
         $record = $this->find($idConditionsOrOptions, $options);
 
@@ -198,7 +198,7 @@ class Repository
         return $record;
     }
 
-    public function first(array $conditionsOrOptions = [], array $options = []): ?Record
+    public function first(array $conditionsOrOptions = [], array $options = []): ?array
     {
         if ($options === [] && $this->isOptionsArray($conditionsOrOptions)) {
             $options = $conditionsOrOptions;
@@ -218,7 +218,7 @@ class Repository
         return $this->applyOptions($query, $options)->first();
     }
 
-    public function firstOrFail(array $conditionsOrOptions = [], array $options = []): Record
+    public function firstOrFail(array $conditionsOrOptions = [], array $options = []): array
     {
         $record = $this->first($conditionsOrOptions, $options);
 
@@ -229,7 +229,7 @@ class Repository
         return $record;
     }
 
-    public function get(array $conditionsOrOptions = [], array $options = []): Collection
+    public function get(array $conditionsOrOptions = [], array $options = []): array
     {
         if ($options === [] && $this->isOptionsArray($conditionsOrOptions)) {
             $options = $conditionsOrOptions;
@@ -328,12 +328,12 @@ class Repository
         return $result;
     }
 
-    public function getById(string $id, array $options = []): ?Record
+    public function getById(string $id, array $options = []): ?array
     {
         return $this->find($id, $options);
     }
 
-    public function firstOrCreate(array $attributes, array $extra = []): Record
+    public function firstOrCreate(array $attributes, array $extra = []): array
     {
         $query = $this->newQuery();
 
@@ -352,7 +352,7 @@ class Repository
         return $this->findOrFail(['Id' => $result['id']]);
     }
 
-    public function updateOrCreate(array $attributes, array $values = []): Record
+    public function updateOrCreate(array $attributes, array $values = []): array
     {
         $query = $this->newQuery();
 


### PR DESCRIPTION
## Summary
- decouple base repository from Record and Collection classes
- move Record and Collection implementations under the Api integration namespace
- adapt API bridge classes to convert arrays to result objects
- update query builder to return arrays
- remove repetitive transformation code by adding a helper

## Testing
- `composer validate --strict`
- `find src -name '*.php' | xargs -I{} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_688ce9d6cbb0832587d83c32433cf0d5