### PR TITLE
feat: add Salesforce record types

### DIFF
--- a/src/SfCollection.php
+++ b/src/SfCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration;
+
+use Aggregate\Set;
+
+class SfCollection extends Set
+{
+    public static function make(array $records): static
+    {
+        return (new static)->fill($records);
+    }
+
+    public function toArray(): array
+    {
+        return array_map(fn (SfRecord $record) => $record->toArray(), $this->all());
+    }
+}

--- a/src/SfRecord.php
+++ b/src/SfRecord.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration;
+
+use Aggregate\Map;
+
+class SfRecord extends Map
+{
+    protected array $raw = [];
+
+    public static function make(array $attributes, array $raw): static
+    {
+        return (new static)->fill($attributes)->setRawAttributes($raw);
+    }
+
+    public function setRawAttributes(array $raw): static
+    {
+        $this->raw = $raw;
+
+        return $this;
+    }
+
+    public function getAttributes(): array
+    {
+        return $this->all();
+    }
+
+    public function getAttribute(string $key): mixed
+    {
+        return $this->get($key);
+    }
+
+    public function toArray(): array
+    {
+        return $this->all();
+    }
+
+    public function getRawAttributes(): array
+    {
+        return $this->raw;
+    }
+
+    public function getRawAttribute(string $key): mixed
+    {
+        return $this->raw[$key] ?? null;
+    }
+}


### PR DESCRIPTION
## Summary
- add SfRecord and SfCollection types to carry transformed and raw Salesforce data
- refactor sf* repository methods to return structured records/collections

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890881e62e8832597236fac65ca31cf