### PR TITLE
Adjust Salesforce cache clear tags for updated caching scheme

### DIFF
--- a/src/Integrations/Laravel/Console/ClearCache.php
+++ b/src/Integrations/Laravel/Console/ClearCache.php
@@ -24,9 +24,17 @@ class ClearCache extends Command
             return 1;
         }
 
-        $tags = [$resource];
         if ($id) {
-            $tags[] = $resource . ':' . $id;
+            $tags = [
+                $resource . ':' . $id,
+                $resource . ':findMany',
+            ];
+        } else {
+            $tags = [
+                $resource,
+                $resource . ':findMany',
+                $resource . ':findOne',
+            ];
         }
 
         Cache::tags($tags)->flush();


### PR DESCRIPTION
## Summary
- respect new caching tags in `salesforce:cache:clear` Artisan command
- clear list and single-record cache tags; when an ID is provided also clear the record tag

## Testing
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6890951e3dac8325a4b1ad69413451c9