### PR TITLE
Honor custom identifier on update and delete

### DIFF
--- a/src/Clients/Salesforce.php
+++ b/src/Clients/Salesforce.php
@@ -126,16 +126,32 @@ class Salesforce
         ]);
     }
 
-    public function update(string $object, string $id, array $payload): array
+    public function update(string $object, string $id, array $payload, string $identifier = 'Id'): array
     {
-        return $this->request('PATCH', $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/sobjects/'.trim($object, '/').'/'.trim($id, '/'), [
+        $url = $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/sobjects/'.trim($object, '/');
+
+        if ($identifier !== 'Id') {
+            $url .= '/'.trim($identifier, '/').'/'.trim($id, '/');
+        } else {
+            $url .= '/'.trim($id, '/');
+        }
+
+        return $this->request('PATCH', $url, [
             'json' => $payload,
             'log_request' => true,
         ]);
     }
 
-    public function delete(string $object, string $id): array
+    public function delete(string $object, string $id, string $identifier = 'Id'): array
     {
-        return $this->request('DELETE', $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/sobjects/'.trim($object, '/').'/'.trim($id, '/'), ['log_request' => true]);
+        $url = $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/sobjects/'.trim($object, '/');
+
+        if ($identifier !== 'Id') {
+            $url .= '/'.trim($identifier, '/').'/'.trim($id, '/');
+        } else {
+            $url .= '/'.trim($id, '/');
+        }
+
+        return $this->request('DELETE', $url, ['log_request' => true]);
     }
 }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -293,7 +293,7 @@ class Repository
         $payload = array_replace_recursive($this->defaultValues, $attributes);
         $payload = $this->filterNullDefaults($payload, $attributes);
 
-        $result = $this->getClient()->update($this->object, $id, $payload);
+        $result = $this->getClient()->update($this->object, $id, $payload, $this->defaultIdentifier);
 
         if ($this->cacheHandler) {
             $this->cacheHandler->flush([
@@ -307,7 +307,7 @@ class Repository
 
     public function delete(string $id): array
     {
-        $result = $this->getClient()->delete($this->object, $id);
+        $result = $this->getClient()->delete($this->object, $id, $this->defaultIdentifier);
 
         if ($this->cacheHandler) {
             $this->cacheHandler->flush([


### PR DESCRIPTION
## Summary
- allow specifying an external identifier when updating or deleting Salesforce records
- ensure repositories forward their configured identifier to update/delete calls

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `php -l src/Clients/Salesforce.php`
- `php -l src/Repository.php`


------
https://chatgpt.com/codex/tasks/task_e_68909940bacc832591555f800507bb1c