### PR TITLE
Add option to bypass query cache retrieval

### DIFF
--- a/src/Cache/QueryCacheHandler.php
+++ b/src/Cache/QueryCacheHandler.php
@@ -57,7 +57,7 @@ class QueryCacheHandler
             }
         }
 
-        if ($cache->has($key)) {
+        if (! ($options['skip_cache'] ?? false) && $cache->has($key)) {
             $value = $cache->get($key);
             if (is_array($value)) {
                 if ($options['log_request'] ?? false) {

--- a/src/Query.php
+++ b/src/Query.php
@@ -32,6 +32,8 @@ class Query
 
     protected array $cacheTags = [];
 
+    protected array $cacheOptions = [];
+
     public function __construct(string $object, Salesforce $client, string $identifier = 'Id')
     {
         $this->object = $object;
@@ -50,6 +52,13 @@ class Query
     public function setCacheTags(array $tags): static
     {
         $this->cacheTags = $tags;
+
+        return $this;
+    }
+
+    public function setCacheOptions(array $options): static
+    {
+        $this->cacheOptions = $options;
 
         return $this;
     }
@@ -281,8 +290,10 @@ class Query
 
         $callback = fn () => $this->client->query($soql);
 
+        $options = array_merge(['log_request' => true], $this->cacheOptions);
+
         $results = $this->cacheHandler
-            ? $this->cacheHandler->remember($soql, $callback, $this->cacheTags, ['log_request' => true])
+            ? $this->cacheHandler->remember($soql, $callback, $this->cacheTags, $options)
             : $callback();
 
         return $results;
@@ -346,8 +357,10 @@ class Query
 
         $callback = fn () => $this->client->rawQuery($soql);
 
+        $options = array_merge(['log_request' => true], $this->cacheOptions);
+
         $result = $this->cacheHandler
-            ? $this->cacheHandler->remember($soql, $callback, $this->cacheTags, ['log_request' => true])
+            ? $this->cacheHandler->remember($soql, $callback, $this->cacheTags, $options)
             : $callback();
 
         return $result['totalSize'] ?? 0;

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -140,6 +140,10 @@ class Repository
             $query->offset($options['offset']);
         }
 
+        if (isset($options['skip_cache'])) {
+            $query->setCacheOptions(['skip_cache' => $options['skip_cache']]);
+        }
+
         return $query;
     }
 
@@ -365,7 +369,7 @@ class Repository
 
     protected function isOptionsArray(array $data): bool
     {
-        $optionKeys = ['conditions', 'select', 'includes', 'with', 'order', 'sort', 'limit', 'offset'];
+        $optionKeys = ['conditions', 'select', 'includes', 'with', 'order', 'sort', 'limit', 'offset', 'skip_cache'];
 
         return (bool) array_intersect(array_keys($data), $optionKeys);
     }


### PR DESCRIPTION
## Summary
- allow callers to skip reading from cache when executing queries
- forward cache options from repositories and queries

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -l src/Cache/QueryCacheHandler.php`
- `php -l src/Query.php`
- `php -l src/Repository.php`


------
https://chatgpt.com/codex/tasks/task_e_68909e25d480832592fbe1eba13317ef