### PR TITLE
feat: add fresh repository helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ $account = (new Repository('Account'))
 Related data is returned as a simple array of child records without the
 Salesforce metadata wrappers.
 
+### Creating a fresh repository
+
+When you need a repository for a different object without inheriting the
+current repository's default constraints, includes or schema defaults, use
+`freshRepository`:
+
+```php
+$accountRepo = (new AccountRepository())->setClient($salesforce);
+$facilityRepo = $accountRepo->freshRepository('Museum_Facility__c');
+```
+
+The returned repository is clean and can be configured independently.
+
 ## Lookups
 
 Extend `Lookup` or `CachedLookup` to pull picklist values from Salesforce:

--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -362,6 +362,27 @@ class Repository implements RepositoryInterface
         );
     }
 
+    /**
+     * Create a repository instance with no inherited defaults.
+     */
+    public function freshRepository(?string $object = null): BaseRepository
+    {
+        $object ??= $this->object;
+
+        if (! $object) {
+            throw new \Oilstone\ApiSalesforceIntegration\Exceptions\ObjectNotSpecifiedException();
+        }
+
+        return new BaseRepository(
+            $object,
+            [],
+            [],
+            [],
+            'Id',
+            $this->cacheHandler,
+        );
+    }
+
     protected function newQuery(?string $object = null): Query
     {
         return $this->repository($object)->newQuery();


### PR DESCRIPTION
## Summary
- add `freshRepository` helper to build repository instances without inherited defaults
- document fresh repository usage in README

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -l src/Integrations/Api/Repository.php`


------
https://chatgpt.com/codex/tasks/task_e_6890a1ec07788325a08f18c7c00bf455