### PR TITLE
Expose pluck on base repository

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -247,6 +247,24 @@ class Repository
         return $this->applyOptions($query, $options)->get();
     }
 
+    public function pluck(string $column, ?string $index = null, array $conditionsOrOptions = [], array $options = []): array
+    {
+        if ($options === [] && $this->isOptionsArray($conditionsOrOptions)) {
+            $options = $conditionsOrOptions;
+            $conditions = [];
+        } else {
+            $conditions = $conditionsOrOptions;
+        }
+
+        $query = $this->newQuery()->select([]);
+
+        foreach ($conditions as $field => $value) {
+            $query->where($field, $value);
+        }
+
+        return $this->applyOptions($query, $options)->pluck($column, $index);
+    }
+
     public function count(array $conditionsOrOptions = [], array $options = []): int
     {
         if ($options === [] && $this->isOptionsArray($conditionsOrOptions)) {


### PR DESCRIPTION
## Summary
- expose Query's `pluck` via a new `pluck` method on the base `Repository`

## Testing
- `composer test` (fails: Command "test" is not defined.)
- `./vendor/bin/phpunit` (fails: No such file or directory)
- `php -l src/Repository.php`


------
https://chatgpt.com/codex/tasks/task_e_6890b82cd3dc83258472efdf5f535580