### PR TITLE
Ensure identifier fields included in default schema fields

### DIFF
--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -490,7 +490,9 @@ class Repository implements RepositoryInterface
     }
 
     /**
-     * Gets the default fields from the schema, including nested schema properties.
+     * Gets the default fields from the schema, including nested schema properties,
+     * and ensures identifier fields such as the Salesforce 'Id' and any custom
+     * identifier are present.
      *
      * @return array A flat array of unique field names.
      */
@@ -500,6 +502,14 @@ class Repository implements RepositoryInterface
 
         if ($this->schema) {
             $fields = $this->extractSchemaFields($this->schema);
+        }
+
+        if (! in_array('Id', $fields, true)) {
+            $fields[] = 'Id';
+        }
+
+        if ($this->identifier !== 'Id' && ! in_array($this->identifier, $fields, true)) {
+            $fields[] = $this->identifier;
         }
 
         return array_unique($fields);


### PR DESCRIPTION
## Summary
- always include Salesforce `Id` field in default query field list
- append configured identifier field when different from `Id`

## Testing
- `php -l src/Integrations/Api/Repository.php`
- `composer test` *(fails: Command "test" is not defined.)*


------
https://chatgpt.com/codex/tasks/task_e_6890c5a0c3d483259ce8edfb247d1e60