### PR TITLE
Allow queries on readonly schema fields

### DIFF
--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -450,7 +450,8 @@ class Repository implements RepositoryInterface
             return [];
         }
 
-        $reversed = $this->reverseAttributes($conditions, false);
+        // Force reversing so readonly fields remain available for querying.
+        $reversed = $this->reverseAttributes($conditions, false, true);
 
         if ($this->schema) {
             $reversed = $this->stripDefaultValues($reversed, $this->getDefaultValues(), $conditions);


### PR DESCRIPTION
## Summary
- ensure query conditions include readonly schema properties

## Testing
- `php -l src/Integrations/Api/Repository.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68b6d2216be48325be8160253e32cbf1