### PR TITLE
Add grouped relationship includes and nested child relationship subqueries to Query

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -19,6 +19,8 @@ class Query
 
     protected array $relationships = [];
 
+    protected array $relationshipGroups = [];
+
     protected array $conditions = [];
 
     protected array $orders = [];
@@ -92,19 +94,92 @@ class Query
             return $this;
         }
 
-        $compiled = $this->compileInclude($relation);
-        $this->relationships[] = $compiled;
+        $this->addIncludeToGroups($relation);
 
         return $this;
     }
 
+    protected function addIncludeToGroups(string $relation): void
+    {
+        [$relationPath, $fields] = $this->splitIncludeAndFields($relation);
+
+        $parts = array_values(array_filter(explode('.', $relationPath), fn ($part) => trim($part) !== ''));
+
+        if (! $parts) {
+            return;
+        }
+
+        $rootRelationship = $this->childRelationshipMetadata($this->object, $parts[0]);
+        $root = $rootRelationship['relationshipName'] ?? $parts[0];
+        $rootObject = $rootRelationship['childSObject'] ?? null;
+
+        if (! isset($this->relationshipGroups[$root])) {
+            $this->relationshipGroups[$root] = ['fields' => [], 'subqueries' => []];
+        }
+
+        if (count($parts) === 1) {
+            foreach ($this->normaliseFieldList($fields) as $field) {
+                $this->relationshipGroups[$root]['fields'][$field] = true;
+            }
+
+            return;
+        }
+
+        $path = implode('.', array_slice($parts, 1));
+
+        if ($this->isNestedChildRelationshipPath($rootObject, $path)) {
+            $subquery = $this->compileNestedSubquery($path, $fields);
+            $this->relationshipGroups[$root]['subqueries'][$subquery] = true;
+
+            return;
+        }
+
+        foreach ($this->normaliseFieldList($fields) as $field) {
+            $this->relationshipGroups[$root]['fields'][$path.'.'.$field] = true;
+        }
+    }
+
+    protected function splitIncludeAndFields(string $relation): array
+    {
+        if (! str_contains($relation, ':')) {
+            return [$relation, ''];
+        }
+
+        return explode(':', $relation, 2);
+    }
+
+    protected function normaliseFieldList(string $fields): array
+    {
+        $fieldList = array_filter(array_map(function ($field) {
+            return trim($field);
+        }, explode(',', $fields)));
+
+        if (! $fieldList) {
+            return [$this->identifier, 'Name'];
+        }
+
+        return $fieldList;
+    }
+
+    protected function isNestedChildRelationshipPath(?string $object, string $path): bool
+    {
+        if (! $object || str_contains($path, '.')) {
+            return false;
+        }
+
+        return (bool) $this->childRelationshipMetadata($object, $path);
+    }
+
+    protected function compileNestedSubquery(string $relationship, string $fields): string
+    {
+        $fieldString = implode(', ', $this->normaliseFieldList($fields));
+
+        return sprintf('(SELECT %s FROM %s)', $fieldString, $relationship);
+    }
+
     protected function compileInclude(string $relation): string
     {
-        $fields = '';
-
-        if (str_contains($relation, ':')) {
-            [$relation, $fields] = explode(':', $relation, 2);
-        }
+        [$relation, $fields] = $this->splitIncludeAndFields($relation);
 
         $parts = explode('.', $relation, 2);
 
@@ -119,13 +194,7 @@ class Query
             }
         }
 
-        $fieldList = array_filter(array_map(function ($field) {
-            return trim($field);
-        }, explode(',', $fields)));
-
-        if (! $fieldList) {
-            $fieldList = [$this->identifier, 'Name'];
-        }
+        $fieldList = $this->normaliseFieldList($fields);
 
         if ($prefix) {
             $fieldList = array_map(fn ($field) => sprintf('%s.%s', $prefix, $field), $fieldList);
@@ -138,15 +207,20 @@ class Query
 
     protected function childRelationshipName(string $object): ?string
     {
-        $describe = $this->describe($this->object);
+        return $this->childRelationshipMetadata($this->object, $object)['relationshipName'] ?? null;
+    }
+
+    protected function childRelationshipMetadata(string $object, string $relationshipOrChildObject): ?array
+    {
+        $describe = $this->describe($object);
 
         foreach ($describe['childRelationships'] ?? [] as $relationship) {
-            if (strcasecmp($relationship['childSObject'] ?? '', $object) === 0) {
-                return $relationship['relationshipName'] ?? null;
+            if (strcasecmp($relationship['childSObject'] ?? '', $relationshipOrChildObject) === 0) {
+                return $relationship;
             }
 
-            if (strcasecmp($relationship['relationshipName'] ?? '', $object) === 0) {
-                return $relationship['relationshipName'];
+            if (strcasecmp($relationship['relationshipName'] ?? '', $relationshipOrChildObject) === 0) {
+                return $relationship;
             }
         }
 
@@ -344,14 +418,17 @@ class Query
     {
         $originalSelects = $this->selects;
         $originalRelationships = $this->relationships;
+        $originalRelationshipGroups = $this->relationshipGroups;
 
         $this->selects = ['COUNT()'];
         $this->relationships = [];
+        $this->relationshipGroups = [];
 
         $soql = $this->toSoql();
 
         $this->selects = $originalSelects;
         $this->relationships = $originalRelationships;
+        $this->relationshipGroups = $originalRelationshipGroups;
 
         $callback = fn () => $this->client->rawQuery($soql);
 
@@ -417,7 +494,16 @@ class Query
 
     protected function toSoql(): string
     {
-        $select = implode(', ', array_merge($this->selects ?: [$this->identifier], $this->relationships));
+        $groupedRelationships = array_map(function (string $relation, array $parts) {
+            $fields = array_keys($parts['fields']);
+            $subqueries = array_keys($parts['subqueries']);
+
+            $fieldString = implode(', ', array_merge($fields, $subqueries));
+
+            return sprintf('(SELECT %s FROM %s)', $fieldString, $relation);
+        }, array_keys($this->relationshipGroups), $this->relationshipGroups);
+
+        $select = implode(', ', array_merge($this->selects ?: [$this->identifier], $this->relationships, $groupedRelationships));
         $query = "SELECT {$select} FROM {$this->object}";
 
         if ($this->conditions) {

--- a/src/Query.php
+++ b/src/Query.php
@@ -134,9 +134,22 @@ class Query
             return;
         }
 
+        $traversalPath = $this->normaliseTraversalPath($path);
+
         foreach ($this->normaliseFieldList($fields) as $field) {
-            $this->relationshipGroups[$root]['fields'][$path.'.'.$field] = true;
+            $this->relationshipGroups[$root]['fields'][$traversalPath.'.'.$field] = true;
         }
+    }
+
+    protected function normaliseTraversalPath(string $path): string
+    {
+        return implode('.', array_map(function (string $segment) {
+            if (str_ends_with($segment, '__c')) {
+                return substr($segment, 0, -3).'__r';
+            }
+
+            return $segment;
+        }, explode('.', $path)));
     }
 
     protected function splitIncludeAndFields(string $relation): array
@@ -188,10 +201,7 @@ class Query
 
         $prefix = null;
         if (count($parts) > 1) {
-            $prefix = $parts[1];
-            if (str_ends_with($prefix, '__c')) {
-                $prefix = substr($prefix, 0, -3).'__r';
-            }
+            $prefix = $this->normaliseTraversalPath($parts[1]);
         }
 
         $fieldList = $this->normaliseFieldList($fields);


### PR DESCRIPTION
### Motivation
- Improve handling of `with()` relationship includes so fields and nested child relationship subqueries can be grouped and compiled correctly into SOQL `SELECT` subqueries. 
- Allow passing field lists on includes (e.g. `Relation:Id,Name`) and detect when a path represents a child relationship so a nested `(SELECT ...) FROM ...` subquery is emitted. 
- Normalize include parsing and metadata lookup to support child relationship names and avoid duplicating raw relationship strings in the select list.

### Description
- Introduce a `relationshipGroups` property and populate it from `with()` via `addIncludeToGroups`, which parses include strings and groups fields and subqueries. 
- Add helper methods `splitIncludeAndFields`, `normaliseFieldList`, `isNestedChildRelationshipPath`, `compileNestedSubquery`, and `childRelationshipMetadata` to parse includes, default field lists to the identifier/`Name`, detect nested child relationships, and resolve relationship metadata. 
- Update `compileInclude` and `childRelationshipName` to use the new metadata-driven logic and normalized field lists. 
- Update `toSoql` to merge grouped relationship subqueries into the `SELECT` clause, and ensure `count()` preserves and restores `relationshipGroups` during execution.

### Testing
- Ran the project's automated unit test suite with `phpunit` and the test run completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29ab6286c83259bda37fc56c522ce)