### PR TITLE
Fix numeric-string quoting in SOQL condition formatter

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -585,6 +585,10 @@ class Query
             return $value ? 'TRUE' : 'FALSE';
         }
 
-        return is_numeric($value) ? (string) $value : "'".addslashes($value)."'";
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        return "'".addslashes((string) $value)."'";
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent numeric-looking strings from being emitted unquoted in generated SOQL so string-typed Salesforce fields (e.g. `SchoolURN__c`) receive quoted filter values.

### Description
- Change `Query::formatValue()` in `src/Query.php` to only treat native numeric types (`int`/`float`) as unquoted literals and to always cast and quote other values as strings.

### Testing
- Ran `php -l src/Query.php` to verify there are no syntax errors and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78afacd208325b81265bfc99a4b88)