### PR TITLE
Add flowAction() to Salesforce client

### DIFF
--- a/src/Clients/Salesforce.php
+++ b/src/Clients/Salesforce.php
@@ -162,6 +162,20 @@ class Salesforce
         return $this->request('DELETE', $url, ['log_request' => true]);
     }
 
+    public function flowAction(string $flowName, array $inputs): array
+    {
+        return $this->request(
+            'POST',
+            $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/actions/custom/flow/'.trim($flowName, '/'),
+            [
+                'json' => [
+                    'inputs' => $inputs,
+                ],
+                'log_request' => true,
+            ],
+        );
+    }
+
     public function apexRest(string $method, string $path, array $options = []): array
     {
         $url = $this->instanceUrl.'/services/apexrest/'.ltrim($path, '/');


### PR DESCRIPTION
### Motivation
- Add a convenience method to invoke Salesforce custom flow actions using the existing authenticated client so callers can trigger flows while reusing instance URL/version, request logging, and error handling.

### Description
- Added `public function flowAction(string $flowName, array $inputs): array` to `src/Clients/Salesforce.php` that POSTs to `/services/data/{version}/actions/custom/flow/{flowName}` with `json => ['inputs' => $inputs]` and `log_request => true`, delegating to the existing `request()` pipeline which provides authorization and `SalesforceException::fromResponse()` handling.

### Testing
- Ran `php -l src/Clients/Salesforce.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1e9ae79c8325b7f7e2046e6c7644)