### PR TITLE
Harden cache invalidation, isolate schema cache, refresh tokens on 401

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,40 +35,83 @@ If your project uses Laravel you can register the service provider and publish t
 php artisan vendor:publish --tag=config --provider="Oilstone\\ApiSalesforceIntegration\\Integrations\\Laravel\\ServiceProvider"
 ```
 
-Configure your Salesforce instance in `config/salesforce.php` and the provider will handle authentication and caching of access tokens. When the `debug` option is enabled each request and response is logged via Laravel's logger. Queries served from the cache are also logged with a `cache` flag so they can be distinguished from live requests. When the package is resolved inside an Artisan command, scheduler task or queued job the query cache is still populated but lookups default to the live API to avoid stale data in long-running console processes.
+Configure your Salesforce instance in `config/salesforce.php` and the provider will handle authentication and caching of access tokens. When the `debug` option is enabled each request and response is logged via Laravel's logger. Queries served from the cache are also logged with a `cache` flag so they can be distinguished from live requests.
+
+OAuth access tokens are managed by `SalesforceTokenManager`, which caches the
+token under the key `salesforce.access_token`, derives its TTL from the
+`expires_in` field returned by Salesforce (with a 60 second safety margin),
+serialises concurrent token fetches with a cache lock to avoid thundering-herd
+requests, and transparently refreshes the token if any Salesforce call returns
+HTTP 401. This works out of the box with the Redis cache store.
 
 When authenticating with the client credentials grant you must supply at least one OAuth scope. Set the `SALESFORCE_SCOPES` environment variable to a comma separated list (or define the `scopes` array in the published configuration) and the service provider will include them in the token request.
 
-The package divides caching into two layers via `QueryCacheHandler`:
+The package divides caching into three independent layers via
+`QueryCacheHandler`:
 
 * **Query cache** entries persist the results of SOQL queries for a short TTL.
   The SOQL string itself is hashed to generate the cache key and a single
-  `flushQueryCache` method clears every cached query in one call.
-* **Entry cache** entries store individual records for a longer TTL. Keys are
-  derived from the queried object's conditions, ensuring `find`, `first` and
-  similar operations can reuse cached records. Entry cache items can be
-  removed on demand by passing the same conditions back to the handler.
+  `flushQueryCache` method invalidates every cached query in one call by
+  rotating an internal namespace token. The query cache is also flushed
+  automatically by any repository mutation (`create`, `update`, `upsert`,
+  `upsertRecord`, `delete`).
+* **Entry cache** entries store individual records returned from `find` /
+  `first` lookups for a longer TTL. Each cached entry is indexed under every
+  configured "indexable field" (the record's `Id` by default, plus any extra
+  unique columns you register via `setIndexableFields`). Mutations invalidate
+  the entry under each known indexable field so a record cached by `Email`
+  remains in sync after an update keyed by `Id`. Negative results (`null` for
+  "not found") are deliberately not cached, so a subsequent `create` is never
+  fooled by a stale miss.
+* **Schema cache** entries store object describe payloads and picklist value
+  responses, which rarely change. Schema entries live in their own namespace
+  and are **not** affected by `flushQueryCache`, so the (expensive) describe
+  call is preserved across data mutations. Use `flushSchemaCache` or the
+  `--schema` flag on the Artisan command to invalidate them after a Salesforce
+  metadata change.
 
-Use the Artisan command to clear caches:
+### Configuring entry cache invalidation
 
-```bash
-php artisan salesforce:cache:clear Account              # Flushes all query cache entries
-php artisan salesforce:cache:clear Account 001XXXXXXXXXXXXXXX
-php artisan salesforce:cache:clear Account 001XXXXXXXXXXXXXXX --field=External_Id__c
+By default the entry cache is keyed by the repository's identifier (`Id`, or
+whatever you set with `setIdentifier`). If you also look records up by other
+unique fields (an external ID, an email column, etc.), register them so
+mutations can invalidate every cached copy:
+
+```php
+$repository = (new Repository('Contact'))
+    ->setIdentifier('Id')
+    ->setIndexableFields(['Id', 'Email', 'External_Id__c']);
 ```
 
-Supplying an ID (and optionally an alternate field) clears both the query
-cache and the targeted entry cache for that record. Repository `create`,
-`update`, `upsertRecord` and `delete` operations automatically flush the query
-cache, and updates/upserts/deletions evict the related entry cache entry so
-fresh data is fetched next time.
+Only register fields that uniquely identify a record. Non-unique fields (e.g.
+`Status`) are not appropriate as indexable fields. Note that if the value of
+an indexable field changes during an update, the cache entry keyed under the
+old value is left to expire via TTL — this is rarely a problem when
+indexable fields are immutable identifiers.
 
-Default TTLs can be configured via the `SALESFORCE_QUERY_CACHE_DEFAULT_TTL`
-and `SALESFORCE_ENTRY_CACHE_DEFAULT_TTL` environment variables (or their
-respective `salesforce.php` configuration values).
+### Clearing caches manually
 
-Object descriptions fetched via the client are also cached through the same
-handler, preventing repetitive calls to Salesforce's `describe` endpoint.
+```bash
+php artisan salesforce:cache:clear                                          # Flushes all query cache entries
+php artisan salesforce:cache:clear Account 001XXXXXXXXXXXXXXX               # Also forgets the entry cache for that Id
+php artisan salesforce:cache:clear Account 001XXXXXXXXXXXXXXX --field=External_Id__c
+php artisan salesforce:cache:clear --schema                                 # Flushes only the schema cache
+```
+
+### Configuration
+
+Default TTLs and behaviour can be configured via environment variables (or the
+corresponding keys in the published `salesforce.php` configuration file):
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SALESFORCE_QUERY_CACHE_DEFAULT_TTL` | `3600` | TTL (seconds) for cached SOQL query results. |
+| `SALESFORCE_ENTRY_CACHE_DEFAULT_TTL` | `86400` | TTL (seconds) for cached individual records. |
+| `SALESFORCE_SCHEMA_CACHE_DEFAULT_TTL` | `86400` | TTL (seconds) for cached describe / picklist payloads. |
+| `SALESFORCE_SKIP_RETRIEVAL_DEFAULT` | `false` | When `true`, every cached lookup bypasses the cache on the way in (cache is still populated). Useful for long-running queue workers that need fresh reads. |
+
+You can also opt out of the cache on a single call by passing
+`'skip_retrieval' => true` in the repository options array.
 
 ## Basic usage
 

--- a/src/Auth/StaticTokenManager.php
+++ b/src/Auth/StaticTokenManager.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration\Auth;
+
+class StaticTokenManager implements TokenManager
+{
+    public function __construct(protected string $token) {}
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function refresh(): string
+    {
+        return $this->token;
+    }
+}

--- a/src/Auth/TokenManager.php
+++ b/src/Auth/TokenManager.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration\Auth;
+
+interface TokenManager
+{
+    public function getToken(): string;
+
+    public function refresh(): string;
+}

--- a/src/Cache/QueryCacheHandler.php
+++ b/src/Cache/QueryCacheHandler.php
@@ -10,7 +10,9 @@ class QueryCacheHandler
 {
     protected string $queryPrefix = 'salesforce.query.';
     protected string $entryPrefix = 'salesforce.entry.';
+    protected string $schemaPrefix = 'salesforce.schema.';
     protected string $queryNamespaceKey = 'salesforce.query.namespace';
+    protected string $schemaNamespaceKey = 'salesforce.schema.namespace';
     protected string $entryIndexPrefix = 'salesforce.entry_index.';
 
     protected bool $skipRetrievalByDefault = false;
@@ -19,7 +21,8 @@ class QueryCacheHandler
         protected CacheInterface $cache,
         protected ?int $queryTtl = null,
         protected ?int $entryTtl = null,
-        protected ?LoggerInterface $logger = null
+        protected ?LoggerInterface $logger = null,
+        protected ?int $schemaTtl = null,
     ) {}
 
     public function setLogger(?LoggerInterface $logger): static
@@ -48,6 +51,13 @@ class QueryCacheHandler
         return $this;
     }
 
+    public function setSchemaTtl(?int $ttl): static
+    {
+        $this->schemaTtl = $ttl;
+
+        return $this;
+    }
+
     public function skipRetrievalByDefault(bool $skip = true): static
     {
         $this->skipRetrievalByDefault = $skip;
@@ -62,9 +72,28 @@ class QueryCacheHandler
 
     public function rememberQuery(string $soql, callable $callback, array $options = []): mixed
     {
-        $cacheKey = $this->buildQueryCacheKey($soql);
+        return $this->rememberWithNamespace(
+            $soql,
+            $callback,
+            $this->queryPrefix,
+            $this->queryNamespaceKey,
+            $this->queryTtl,
+            'query',
+            $options
+        );
+    }
 
-        return $this->rememberWithCache($cacheKey, $callback, $this->queryTtl, $options, 'query', $soql);
+    public function rememberSchema(string $key, callable $callback, array $options = []): mixed
+    {
+        return $this->rememberWithNamespace(
+            $key,
+            $callback,
+            $this->schemaPrefix,
+            $this->schemaNamespaceKey,
+            $this->schemaTtl,
+            'schema',
+            $options
+        );
     }
 
     public function rememberEntry(Query $query, string $soql, callable $callback, array $options = []): mixed
@@ -75,63 +104,73 @@ class QueryCacheHandler
             return $callback();
         }
 
-        $indexableConditions = $this->extractEntryIndexConditions($signature);
+        $indexableFields = $query->getIndexableFields();
 
-        if ($indexableConditions === []) {
-            return $callback();
+        if ($indexableFields === []) {
+            $indexableFields = [$query->getIdentifier()];
         }
 
         $cacheKey = $this->buildEntryCacheKey($query->getObject(), $signature);
+        $context = ['object' => $query->getObject(), 'conditions' => $signature];
 
-        return $this->rememberWithCache(
-            $cacheKey,
-            $callback,
-            $this->entryTtl,
-            $options,
-            'entry',
-            $soql,
-            [
-                'object' => $query->getObject(),
-                'conditions' => $signature,
-            ],
-            function () use ($query, $indexableConditions, $cacheKey): void {
-                $this->registerEntryIndex($query->getObject(), $indexableConditions, $cacheKey);
-            },
-            function () use ($query, $indexableConditions, $cacheKey): void {
-                $this->registerEntryIndex($query->getObject(), $indexableConditions, $cacheKey);
+        $skipRetrieval = $this->shouldSkipRetrieval($options);
+
+        if (! $skipRetrieval && $this->cache->has($cacheKey)) {
+            $value = $this->cache->get($cacheKey);
+
+            if ($options['log_request'] ?? false) {
+                $this->log($soql, $value, 'entry', $context);
             }
-        );
+
+            return $value;
+        }
+
+        $value = $callback();
+
+        if ($value === null) {
+            if ($options['log_request'] ?? false) {
+                $this->log($soql, $value, 'entry', $context);
+            }
+
+            return $value;
+        }
+
+        $this->cache->set($cacheKey, $value, $this->entryTtl);
+
+        if (is_array($value)) {
+            $this->registerEntryIndexFromRecord($query->getObject(), $indexableFields, $value, $cacheKey);
+        }
+
+        if ($options['log_request'] ?? false) {
+            $this->log($soql, $value, 'entry', $context);
+        }
+
+        return $value;
     }
 
     public function forgetEntryByConditions(string $object, array $conditions): void
     {
-        $signature = $this->normaliseConditionsInput($conditions);
-
-        if ($signature === []) {
-            return;
-        }
-
-        $indexableConditions = $this->extractEntryIndexConditions($signature);
-
-        if ($indexableConditions === []) {
+        if ($conditions === []) {
             return;
         }
 
         $keysToDelete = [];
 
-        foreach ($indexableConditions as $field => $values) {
-            foreach ($values as $value) {
-                $indexKey = $this->buildEntryIndexKey($object, $field, $value);
-                $cacheKeys = $this->cache->get($indexKey);
-
-                if (is_array($cacheKeys)) {
-                    foreach ($cacheKeys as $cacheKey) {
-                        $keysToDelete[$cacheKey] = true;
-                    }
-                }
-
-                $this->cache->delete($indexKey);
+        foreach ($conditions as $field => $value) {
+            if (! is_string($field) || $value === null) {
+                continue;
             }
+
+            $indexKey = $this->buildEntryIndexKey($object, $field, $value);
+            $cacheKeys = $this->cache->get($indexKey);
+
+            if (is_array($cacheKeys)) {
+                foreach ($cacheKeys as $cacheKey) {
+                    $keysToDelete[$cacheKey] = true;
+                }
+            }
+
+            $this->cache->delete($indexKey);
         }
 
         foreach (array_keys($keysToDelete) as $cacheKey) {
@@ -144,30 +183,29 @@ class QueryCacheHandler
         $this->cache->set($this->queryNamespaceKey, $this->generateNamespace());
     }
 
-    protected function rememberWithCache(
-        string $cacheKey,
-        callable $callback,
-        ?int $ttl,
-        array $options,
-        string $type,
-        ?string $originalKey = null,
-        array $context = [],
-        ?callable $onCacheHit = null,
-        ?callable $onCacheStore = null
-    ): mixed {
-        $skipCache = array_key_exists('skip_cache', $options)
-            ? (bool) $options['skip_cache']
-            : $this->skipRetrievalByDefault;
+    public function flushSchemaCache(): void
+    {
+        $this->cache->set($this->schemaNamespaceKey, $this->generateNamespace());
+    }
 
-        if (! $skipCache && $this->cache->has($cacheKey)) {
+    protected function rememberWithNamespace(
+        string $originalKey,
+        callable $callback,
+        string $prefix,
+        string $namespaceKey,
+        ?int $ttl,
+        string $type,
+        array $options
+    ): mixed {
+        $cacheKey = $prefix . $this->getNamespace($namespaceKey) . '.' . md5($originalKey);
+
+        $skipRetrieval = $this->shouldSkipRetrieval($options);
+
+        if (! $skipRetrieval && $this->cache->has($cacheKey)) {
             $value = $this->cache->get($cacheKey);
 
-            if ($onCacheHit) {
-                $onCacheHit();
-            }
-
             if ($options['log_request'] ?? false) {
-                $this->log($originalKey ?? $cacheKey, $value, $type, $context);
+                $this->log($originalKey, $value, $type);
             }
 
             return $value;
@@ -177,15 +215,20 @@ class QueryCacheHandler
 
         $this->cache->set($cacheKey, $value, $ttl);
 
-        if ($onCacheStore) {
-            $onCacheStore();
-        }
-
         if ($options['log_request'] ?? false) {
-            $this->log($originalKey ?? $cacheKey, $value, $type, $context);
+            $this->log($originalKey, $value, $type);
         }
 
         return $value;
+    }
+
+    protected function shouldSkipRetrieval(array $options): bool
+    {
+        if (array_key_exists('skip_retrieval', $options)) {
+            return (bool) $options['skip_retrieval'];
+        }
+
+        return $this->skipRetrievalByDefault;
     }
 
     protected function log(string $key, mixed $response, string $type, array $context = []): void
@@ -210,11 +253,6 @@ class QueryCacheHandler
         $this->logger->debug('Salesforce request', $payload);
     }
 
-    protected function buildQueryCacheKey(string $key): string
-    {
-        return $this->queryPrefix . $this->getQueryNamespace() . '.' . md5($key);
-    }
-
     protected function buildEntryCacheKey(string $object, array $signature): string
     {
         $normalised = $this->normaliseArray($signature);
@@ -234,13 +272,13 @@ class QueryCacheHandler
         ], JSON_THROW_ON_ERROR));
     }
 
-    protected function getQueryNamespace(): string
+    protected function getNamespace(string $key): string
     {
-        $namespace = $this->cache->get($this->queryNamespaceKey);
+        $namespace = $this->cache->get($key);
 
         if (! is_string($namespace) || $namespace === '') {
             $namespace = $this->generateNamespace();
-            $this->cache->set($this->queryNamespaceKey, $namespace);
+            $this->cache->set($key, $namespace);
         }
 
         return $namespace;
@@ -255,71 +293,31 @@ class QueryCacheHandler
         }
     }
 
-    protected function extractEntryIndexConditions(array $signature): array
+    protected function registerEntryIndexFromRecord(string $object, array $indexableFields, array $record, string $cacheKey): void
     {
-        $conditions = [];
-
-        foreach ($signature as $condition) {
-            if (! is_array($condition) || ! isset($condition['type'])) {
+        foreach ($indexableFields as $field) {
+            if (! is_string($field) || ! array_key_exists($field, $record)) {
                 continue;
             }
 
-            if ($condition['type'] === 'nested') {
-                $nested = $this->extractEntryIndexConditions($condition['conditions'] ?? []);
+            $value = $record[$field];
 
-                foreach ($nested as $field => $values) {
-                    $conditions[$field] = array_merge($conditions[$field] ?? [], $values);
-                }
-
+            if ($value === null) {
                 continue;
             }
 
-            if (! isset($condition['field'])) {
-                continue;
+            $indexKey = $this->buildEntryIndexKey($object, $field, $value);
+            $cacheKeys = $this->cache->get($indexKey);
+
+            if (! is_array($cacheKeys)) {
+                $cacheKeys = [];
             }
 
-            if ($condition['type'] === 'basic' && ($condition['operator'] ?? null) === '=') {
-                $conditions[$condition['field']][] = $condition['value'] ?? null;
-                continue;
+            if (! in_array($cacheKey, $cacheKeys, true)) {
+                $cacheKeys[] = $cacheKey;
             }
 
-            if ($condition['type'] === 'in') {
-                foreach (($condition['values'] ?? []) as $value) {
-                    $conditions[$condition['field']][] = $value;
-                }
-            }
-        }
-
-        foreach ($conditions as $field => $values) {
-            $normalised = [];
-
-            foreach ($values as $value) {
-                $normalised[] = $this->normaliseValue($value);
-            }
-
-            $conditions[$field] = array_values(array_unique($normalised, SORT_REGULAR));
-        }
-
-        return $conditions;
-    }
-
-    protected function registerEntryIndex(string $object, array $conditions, string $cacheKey): void
-    {
-        foreach ($conditions as $field => $values) {
-            foreach ($values as $value) {
-                $indexKey = $this->buildEntryIndexKey($object, $field, $value);
-                $cacheKeys = $this->cache->get($indexKey);
-
-                if (! is_array($cacheKeys)) {
-                    $cacheKeys = [];
-                }
-
-                if (! in_array($cacheKey, $cacheKeys, true)) {
-                    $cacheKeys[] = $cacheKey;
-                }
-
-                $this->cache->set($indexKey, $cacheKeys, $this->entryTtl);
-            }
+            $this->cache->set($indexKey, $cacheKeys, $this->entryTtl);
         }
     }
 
@@ -342,41 +340,6 @@ class QueryCacheHandler
         }
 
         return $value;
-    }
-
-    protected function normaliseConditionsInput(array $conditions): array
-    {
-        if ($conditions === []) {
-            return [];
-        }
-
-        if ($this->isConditionSignature($conditions)) {
-            return $conditions;
-        }
-
-        $signature = [];
-
-        foreach ($conditions as $field => $value) {
-            $signature[] = [
-                'boolean' => 'and',
-                'type' => 'basic',
-                'field' => $field,
-                'operator' => '=',
-                'value' => $value,
-            ];
-        }
-
-        return $signature;
-    }
-
-    protected function isConditionSignature(array $conditions): bool
-    {
-        if (! isset($conditions[0]) || ! is_array($conditions[0])) {
-            return false;
-        }
-
-        return array_key_exists('boolean', $conditions[0])
-            && array_key_exists('type', $conditions[0]);
     }
 
     protected function normaliseArray(array $data): array

--- a/src/Clients/Salesforce.php
+++ b/src/Clients/Salesforce.php
@@ -3,6 +3,8 @@
 namespace Oilstone\ApiSalesforceIntegration\Clients;
 
 use GuzzleHttp\Client;
+use Oilstone\ApiSalesforceIntegration\Auth\StaticTokenManager;
+use Oilstone\ApiSalesforceIntegration\Auth\TokenManager;
 use Oilstone\ApiSalesforceIntegration\Cache\QueryCacheHandler;
 use Oilstone\ApiSalesforceIntegration\Exceptions\SalesforceException;
 use Psr\Log\LoggerInterface;
@@ -13,7 +15,7 @@ class Salesforce
 
     protected string $instanceUrl;
 
-    protected string $accessToken;
+    protected TokenManager $tokenManager;
 
     protected string $instanceVersion;
 
@@ -21,11 +23,19 @@ class Salesforce
 
     protected ?QueryCacheHandler $cacheHandler = null;
 
-    public function __construct(Client $httpClient, string $instanceUrl, string $accessToken, string $instanceVersion = 'v52.0', ?LoggerInterface $logger = null, ?QueryCacheHandler $cacheHandler = null)
-    {
+    public function __construct(
+        Client $httpClient,
+        string $instanceUrl,
+        string|TokenManager $accessToken,
+        string $instanceVersion = 'v52.0',
+        ?LoggerInterface $logger = null,
+        ?QueryCacheHandler $cacheHandler = null,
+    ) {
         $this->httpClient = $httpClient;
         $this->instanceUrl = rtrim($instanceUrl, '/');
-        $this->accessToken = $accessToken;
+        $this->tokenManager = $accessToken instanceof TokenManager
+            ? $accessToken
+            : new StaticTokenManager($accessToken);
         $this->instanceVersion = $instanceVersion;
         $this->logger = $logger;
         $this->cacheHandler = $cacheHandler;
@@ -45,11 +55,11 @@ class Salesforce
         ]));
     }
 
-    protected function request(string $method, string $url, array $options = []): array
+    protected function request(string $method, string $url, array $options = [], bool $isRetry = false): array
     {
         $response = $this->httpClient->request($method, $url, array_merge([
             'headers' => [
-                'Authorization' => 'Bearer '.$this->accessToken,
+                'Authorization' => 'Bearer '.$this->tokenManager->getToken(),
                 'Accept' => 'application/json',
             ],
             'http_errors' => false,
@@ -60,6 +70,12 @@ class Salesforce
 
         if ($options['log_request'] ?? false) {
             $this->log($method, $url, $options, $data ?? [], $response->getStatusCode());
+        }
+
+        if ($response->getStatusCode() === 401 && ! $isRetry) {
+            $this->tokenManager->refresh();
+
+            return $this->request($method, $url, $options, true);
         }
 
         if ($response->getStatusCode() >= 400) {
@@ -94,7 +110,7 @@ class Salesforce
         );
 
         if ($this->cacheHandler) {
-            return $this->cacheHandler->rememberQuery('DESCRIBE '.$object, $callback, $options);
+            return $this->cacheHandler->rememberSchema('DESCRIBE '.$object, $callback, $options);
         }
 
         return $callback();
@@ -111,7 +127,7 @@ class Salesforce
         );
 
         $data = $this->cacheHandler
-            ? $this->cacheHandler->rememberQuery('PICKLIST_VALUES '.$object.'_'.$recordTypeId.'_'.$field, $callback, $options)
+            ? $this->cacheHandler->rememberSchema('PICKLIST_VALUES '.$object.'_'.$recordTypeId.'_'.$field, $callback, $options)
             : $callback();
 
         return array_values(array_map(
@@ -160,6 +176,20 @@ class Salesforce
         }
 
         return $this->request('DELETE', $url, ['log_request' => true]);
+    }
+
+    public function flowAction(string $flowName, array $inputs): array
+    {
+        return $this->request(
+            'POST',
+            $this->instanceUrl.'/services/data/'.$this->instanceVersion.'/actions/custom/flow/'.trim($flowName, '/'),
+            [
+                'json' => [
+                    'inputs' => $inputs,
+                ],
+                'log_request' => true,
+            ],
+        );
     }
 
     public function apexRest(string $method, string $path, array $options = []): array

--- a/src/Integrations/Api/Repository.php
+++ b/src/Integrations/Api/Repository.php
@@ -33,6 +33,8 @@ class Repository implements RepositoryInterface
 
     protected string $identifier = 'Id';
 
+    protected array $indexableFields = [];
+
     public function __construct(
         protected ?string $object = null,
     ) {}
@@ -92,6 +94,18 @@ class Repository implements RepositoryInterface
     public function getIdentifier(): string
     {
         return $this->identifier;
+    }
+
+    public function setIndexableFields(array $fields): static
+    {
+        $this->indexableFields = array_values(array_unique(array_filter($fields, 'is_string')));
+
+        return $this;
+    }
+
+    public function getIndexableFields(): array
+    {
+        return $this->indexableFields;
     }
 
     public function getByKey(Pipe $pipe): ?ResultRecordInterface
@@ -347,6 +361,8 @@ class Repository implements RepositoryInterface
             $this->getDefaultValues(),
             $this->identifier,
             $this->cacheHandler,
+            null,
+            $this->indexableFields,
         );
     }
 

--- a/src/Integrations/Laravel/Auth/SalesforceTokenManager.php
+++ b/src/Integrations/Laravel/Auth/SalesforceTokenManager.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Oilstone\ApiSalesforceIntegration\Integrations\Laravel\Auth;
+
+use GuzzleHttp\Client;
+use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Oilstone\ApiSalesforceIntegration\Auth\TokenManager;
+
+class SalesforceTokenManager implements TokenManager
+{
+    public function __construct(
+        protected Client $httpClient,
+        protected CacheRepository $cache,
+        protected string $instanceUrl,
+        protected string $clientId,
+        protected string $clientSecret,
+        protected array|string|null $scopes = null,
+        protected string $cacheKey = 'salesforce.access_token',
+        protected string $lockKey = 'salesforce.access_token.lock',
+        protected int $safetyMargin = 60,
+    ) {}
+
+    public function getToken(): string
+    {
+        $cached = $this->cache->get($this->cacheKey);
+
+        if (is_string($cached) && $cached !== '') {
+            return $cached;
+        }
+
+        return $this->fetch();
+    }
+
+    public function refresh(): string
+    {
+        $this->cache->forget($this->cacheKey);
+
+        return $this->fetch();
+    }
+
+    protected function fetch(): string
+    {
+        $lock = $this->cache->lock($this->lockKey, 10);
+        $acquired = false;
+
+        try {
+            $acquired = $lock->block(5);
+        } catch (LockTimeoutException) {
+            $acquired = false;
+        }
+
+        try {
+            $cached = $this->cache->get($this->cacheKey);
+
+            if (is_string($cached) && $cached !== '') {
+                return $cached;
+            }
+
+            return $this->requestNewToken();
+        } finally {
+            if ($acquired) {
+                try {
+                    $lock->release();
+                } catch (\Throwable) {
+                }
+            }
+        }
+    }
+
+    protected function requestNewToken(): string
+    {
+        $formParams = [
+            'grant_type' => 'client_credentials',
+            'client_id' => $this->clientId,
+            'client_secret' => $this->clientSecret,
+        ];
+
+        $scope = $this->normaliseScopes();
+
+        if ($scope !== '') {
+            $formParams['scope'] = $scope;
+        }
+
+        $response = $this->httpClient->post($this->instanceUrl . '/services/oauth2/token', [
+            'form_params' => $formParams,
+        ]);
+
+        $data = json_decode((string) $response->getBody(), true);
+
+        if (! is_array($data) || ! isset($data['access_token'])) {
+            throw new \RuntimeException('Unable to retrieve Salesforce access token.');
+        }
+
+        $expiresIn = isset($data['expires_in']) ? (int) $data['expires_in'] : 3300;
+        $ttl = max(60, $expiresIn - $this->safetyMargin);
+
+        $this->cache->put($this->cacheKey, $data['access_token'], $ttl);
+
+        return $data['access_token'];
+    }
+
+    protected function normaliseScopes(): string
+    {
+        if (is_array($this->scopes)) {
+            return implode(' ', array_filter($this->scopes));
+        }
+
+        if (is_string($this->scopes)) {
+            return trim($this->scopes);
+        }
+
+        return '';
+    }
+}

--- a/src/Integrations/Laravel/Console/ClearCache.php
+++ b/src/Integrations/Laravel/Console/ClearCache.php
@@ -7,7 +7,7 @@ use Oilstone\ApiSalesforceIntegration\Cache\QueryCacheHandler;
 
 class ClearCache extends Command
 {
-    protected $signature = 'salesforce:cache:clear {resource} {id?} {--field=Id}';
+    protected $signature = 'salesforce:cache:clear {resource?} {id?} {--field=Id} {--schema}';
 
     protected $description = 'Clear Salesforce cache entries';
 
@@ -16,14 +16,21 @@ class ClearCache extends Command
         /** @var QueryCacheHandler $handler */
         $handler = app(QueryCacheHandler::class);
 
-        $resource = (string) $this->argument('resource');
+        if ($this->option('schema')) {
+            $handler->flushSchemaCache();
+            $this->info('Cleared Salesforce schema cache (object describes and picklist values).');
+
+            return 0;
+        }
+
+        $resource = $this->argument('resource');
         $id = $this->argument('id');
         $field = (string) $this->option('field');
 
         $handler->flushQueryCache();
 
-        if ($id) {
-            $handler->forgetEntryByConditions($resource, [$field => $id]);
+        if ($resource && $id) {
+            $handler->forgetEntryByConditions((string) $resource, [$field => $id]);
             $this->info(sprintf(
                 'Cleared query cache and entry cache for %s where %s = %s.',
                 $resource,
@@ -34,7 +41,7 @@ class ClearCache extends Command
             return 0;
         }
 
-        $this->info(sprintf('Cleared query cache for %s queries.', $resource));
+        $this->info('Cleared Salesforce query cache.');
 
         return 0;
     }

--- a/src/Integrations/Laravel/ServiceProvider.php
+++ b/src/Integrations/Laravel/ServiceProvider.php
@@ -3,11 +3,12 @@
 namespace Oilstone\ApiSalesforceIntegration\Integrations\Laravel;
 
 use GuzzleHttp\Client;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use Oilstone\ApiSalesforceIntegration\Auth\TokenManager;
 use Oilstone\ApiSalesforceIntegration\Cache\QueryCacheHandler;
 use Oilstone\ApiSalesforceIntegration\Clients\Salesforce;
+use Oilstone\ApiSalesforceIntegration\Integrations\Laravel\Auth\SalesforceTokenManager;
 use Oilstone\ApiSalesforceIntegration\Integrations\Laravel\Console\ClearCache;
 
 class ServiceProvider extends BaseServiceProvider
@@ -26,51 +27,36 @@ class ServiceProvider extends BaseServiceProvider
                 $cache,
                 $config['query_cache_default_ttl'],
                 $config['entry_cache_default_ttl'],
-                $logger
-            ))->skipRetrievalByDefault($app->runningInConsole());
+                $logger,
+                $config['schema_cache_default_ttl'],
+            ))->skipRetrievalByDefault((bool) ($config['skip_retrieval_default'] ?? false));
         });
 
-        $this->app->singleton(Salesforce::class, function () use ($config) {
+        $this->app->singleton(TokenManager::class, function ($app) use ($config) {
+            return new SalesforceTokenManager(
+                new Client,
+                $app->make('cache.store'),
+                $config['instance_url'],
+                $config['client_id'],
+                $config['client_secret'],
+                $config['scopes'] ?? null,
+            );
+        });
+
+        $this->app->singleton(Salesforce::class, function ($app) use ($config) {
             $client = new Client;
-
-            $token = Cache::remember('salesforce.access_token', 55 * 60, function () use ($client, $config) {
-                $formParams = [
-                    'grant_type' => 'client_credentials',
-                    'client_id' => $config['client_id'],
-                    'client_secret' => $config['client_secret'],
-                ];
-
-                $scopeConfig = $config['scopes'] ?? null;
-
-                if (is_array($scopeConfig)) {
-                    $scopeConfig = implode(' ', array_filter($scopeConfig));
-                } elseif (is_string($scopeConfig)) {
-                    $scopeConfig = trim($scopeConfig);
-                } else {
-                    $scopeConfig = '';
-                }
-
-                if ($scopeConfig !== '') {
-                    $formParams['scope'] = $scopeConfig;
-                }
-
-                $response = $client->post($config['instance_url'].'/services/oauth2/token', [
-                    'form_params' => $formParams,
-                ]);
-
-                $data = json_decode((string) $response->getBody(), true);
-
-                if (! isset($data['access_token'])) {
-                    throw new \RuntimeException('Unable to retrieve Salesforce access token.');
-                }
-
-                return $data['access_token'];
-            });
-
-            $queryCacheHandler = $this->app->make(QueryCacheHandler::class);
+            $tokenManager = $app->make(TokenManager::class);
+            $queryCacheHandler = $app->make(QueryCacheHandler::class);
             $logger = ! empty($config['debug']) ? Log::channel() : null;
 
-            return new Salesforce($client, $config['instance_url'], $token, $config['instance_version'], $logger, $queryCacheHandler);
+            return new Salesforce(
+                $client,
+                $config['instance_url'],
+                $tokenManager,
+                $config['instance_version'],
+                $logger,
+                $queryCacheHandler,
+            );
         });
     }
 

--- a/src/Integrations/Laravel/config/salesforce.php
+++ b/src/Integrations/Laravel/config/salesforce.php
@@ -8,5 +8,7 @@ return [
     'debug' => env('SALESFORCE_DEBUG', false),
     'query_cache_default_ttl' => env('SALESFORCE_QUERY_CACHE_DEFAULT_TTL', 3600),
     'entry_cache_default_ttl' => env('SALESFORCE_ENTRY_CACHE_DEFAULT_TTL', 86400),
+    'schema_cache_default_ttl' => env('SALESFORCE_SCHEMA_CACHE_DEFAULT_TTL', 86400),
+    'skip_retrieval_default' => env('SALESFORCE_SKIP_RETRIEVAL_DEFAULT', false),
     'scopes' => array_filter(array_map('trim', explode(',', (string) env('SALESFORCE_SCOPES', '')))),
 ];

--- a/src/Query.php
+++ b/src/Query.php
@@ -33,6 +33,8 @@ class Query
 
     protected array $cacheOptions = [];
 
+    protected array $indexableFields = [];
+
     public function __construct(string $object, Salesforce $client, string $identifier = 'Id')
     {
         $this->object = $object;
@@ -53,6 +55,18 @@ class Query
         $this->cacheOptions = $options;
 
         return $this;
+    }
+
+    public function setIndexableFields(array $fields): static
+    {
+        $this->indexableFields = array_values(array_unique(array_filter($fields, 'is_string')));
+
+        return $this;
+    }
+
+    public function getIndexableFields(): array
+    {
+        return $this->indexableFields;
     }
 
     public static function make(string $object, Salesforce $client, string $identifier = 'Id'): static
@@ -390,9 +404,9 @@ class Query
 
     public function pluck(string $column, ?string $index = null): array
     {
-        $originalSelects = $this->selects;
+        $query = clone $this;
 
-        $selects = $this->selects;
+        $selects = $query->selects;
 
         if (! in_array($column, $selects, true)) {
             $selects[] = $column;
@@ -402,11 +416,9 @@ class Query
             $selects[] = $index;
         }
 
-        $this->select($selects);
+        $query->select($selects);
 
-        $results = $this->get();
-
-        $this->selects = $originalSelects;
+        $results = $query->get();
 
         $values = [];
 

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -8,6 +8,8 @@ use Oilstone\ApiSalesforceIntegration\Exceptions\RecordNotFoundException;
 
 class Repository
 {
+    protected array $indexableFields;
+
     public function __construct(
         protected string $object,
         protected array $defaultConstraints = [],
@@ -16,7 +18,12 @@ class Repository
         protected string $defaultIdentifier = 'Id',
         protected ?QueryCacheHandler $cacheHandler = null,
         protected ?Salesforce $client = null,
-    ) {}
+        array $indexableFields = [],
+    ) {
+        $this->indexableFields = $indexableFields !== []
+            ? array_values(array_unique($indexableFields))
+            : [$defaultIdentifier];
+    }
 
     public function setDefaultConstraints(array $constraints): static
     {
@@ -34,7 +41,17 @@ class Repository
 
     public function setIdentifier(string $identifier): static
     {
+        $previous = $this->defaultIdentifier;
         $this->defaultIdentifier = $identifier;
+
+        $position = array_search($previous, $this->indexableFields, true);
+
+        if ($position !== false) {
+            $this->indexableFields[$position] = $identifier;
+            $this->indexableFields = array_values(array_unique($this->indexableFields));
+        } elseif (! in_array($identifier, $this->indexableFields, true)) {
+            array_unshift($this->indexableFields, $identifier);
+        }
 
         return $this;
     }
@@ -70,6 +87,24 @@ class Repository
         return $this;
     }
 
+    public function setIndexableFields(array $fields): static
+    {
+        $fields = array_values(array_unique(array_filter($fields, 'is_string')));
+
+        if (! in_array($this->defaultIdentifier, $fields, true)) {
+            array_unshift($fields, $this->defaultIdentifier);
+        }
+
+        $this->indexableFields = $fields;
+
+        return $this;
+    }
+
+    public function getIndexableFields(): array
+    {
+        return $this->indexableFields;
+    }
+
     public function newQuery(?string $object = null): Query
     {
         $query = new Query($object ?? $this->object, $this->getClient(), $this->defaultIdentifier);
@@ -77,6 +112,8 @@ class Repository
         if ($this->cacheHandler) {
             $query->setCacheHandler($this->cacheHandler);
         }
+
+        $query->setIndexableFields($this->indexableFields);
 
         foreach ($this->defaultConstraints as $constraint) {
             if (is_array($constraint)) {
@@ -136,8 +173,8 @@ class Repository
             $query->offset($options['offset']);
         }
 
-        if (isset($options['skip_cache'])) {
-            $query->setCacheOptions(['skip_cache' => $options['skip_cache']]);
+        if (isset($options['skip_retrieval'])) {
+            $query->setCacheOptions(['skip_retrieval' => $options['skip_retrieval']]);
         }
 
         return $query;
@@ -269,18 +306,7 @@ class Repository
             $query->where($field, $value);
         }
 
-        foreach ($options['conditions'] ?? [] as $condition) {
-            if (is_callable($condition)) {
-                $condition($query);
-                continue;
-            }
-
-            if (is_array($condition)) {
-                $query->where(...$condition);
-            }
-        }
-
-        return $query->count();
+        return $this->applyOptions($query, $options)->count();
     }
 
     public function create(array $attributes): array
@@ -300,7 +326,7 @@ class Repository
             return array_merge($payload, $result ?? []);
         }
 
-        return $this->findOrFail(['Id' => $recordId]);
+        return $this->findOrFail([$this->defaultIdentifier => $recordId], ['skip_retrieval' => true]);
     }
 
     public function update(string $id, array $attributes): array
@@ -308,16 +334,13 @@ class Repository
         $payload = array_replace_recursive($this->defaultValues, $attributes);
         $payload = $this->filterNullDefaults($payload, $attributes);
 
-        $result = $this->getClient()->update($this->object, $id, $payload, $this->defaultIdentifier);
+        $stale = $this->captureStaleForInvalidation([$this->defaultIdentifier => $id]);
 
-        if ($this->cacheHandler) {
-            $this->cacheHandler->flushQueryCache();
-            $this->cacheHandler->forgetEntryByConditions($this->object, [
-                $this->defaultIdentifier => $id,
-            ]);
-        }
+        $this->getClient()->update($this->object, $id, $payload, $this->defaultIdentifier);
 
-        return $this->findOrFail([$this->defaultIdentifier => $id]);
+        $this->invalidateAfterMutation($id, $stale, $payload);
+
+        return $this->findOrFail([$this->defaultIdentifier => $id], ['skip_retrieval' => true]);
     }
 
     public function upsertRecord(string $identifierValue, array $attributes, ?string $identifier = null): array
@@ -327,31 +350,27 @@ class Repository
 
         $identifier ??= $this->defaultIdentifier;
 
-        $result = $this->getClient()->upsert($this->object, $identifierValue, $payload, $identifier);
+        $stale = $this->captureStaleForInvalidation([$identifier => $identifierValue]);
+
+        $this->getClient()->upsert($this->object, $identifierValue, $payload, $identifier);
 
         if ($this->cacheHandler) {
             $this->cacheHandler->flushQueryCache();
-            $this->cacheHandler->forgetEntryByConditions($this->object, [
-                $identifier => $identifierValue,
-            ]);
+            $this->cacheHandler->forgetEntryByConditions($this->object, [$identifier => $identifierValue]);
 
-            if ($identifier !== $this->defaultIdentifier) {
-                $defaultIdentifierValue = $payload[$this->defaultIdentifier] ?? $result[$this->defaultIdentifier] ?? $result['id'] ?? null;
-
-                if ($defaultIdentifierValue !== null) {
-                    $this->cacheHandler->forgetEntryByConditions($this->object, [
-                        $this->defaultIdentifier => $defaultIdentifierValue,
-                    ]);
-                }
+            if (is_array($stale)) {
+                $this->forgetIndexableFields($stale, $payload);
+            } else {
+                $this->forgetPayloadIndexableFields($payload);
             }
         }
 
-        return $this->findOrFail([$identifier => $identifierValue]);
+        return $this->findOrFail([$identifier => $identifierValue], ['skip_retrieval' => true]);
     }
 
     public function upsert(array $conditions, array $attributes): array
     {
-        $existing = $this->first($conditions);
+        $existing = $this->first($conditions, ['skip_retrieval' => true]);
 
         if ($existing) {
             return $this->update($existing[$this->defaultIdentifier], $attributes);
@@ -362,13 +381,17 @@ class Repository
 
     public function delete(string $id): array
     {
+        $stale = $this->captureStaleForInvalidation([$this->defaultIdentifier => $id]);
+
         $result = $this->getClient()->delete($this->object, $id, $this->defaultIdentifier);
 
         if ($this->cacheHandler) {
             $this->cacheHandler->flushQueryCache();
-            $this->cacheHandler->forgetEntryByConditions($this->object, [
-                $this->defaultIdentifier => $id,
-            ]);
+            $this->cacheHandler->forgetEntryByConditions($this->object, [$this->defaultIdentifier => $id]);
+
+            if (is_array($stale)) {
+                $this->forgetIndexableFields($stale);
+            }
         }
 
         return $result;
@@ -387,7 +410,10 @@ class Repository
             $query->where($field, $value);
         }
 
-        $record = $this->applyOptions($query, ['select' => ['FIELDS(ALL)']])->first();
+        $record = $this->applyOptions($query, [
+            'select' => ['FIELDS(ALL)'],
+            'skip_retrieval' => true,
+        ])->first();
 
         if ($record) {
             return $record;
@@ -404,7 +430,10 @@ class Repository
             $query->where($field, $value);
         }
 
-        $record = $this->applyOptions($query, ['select' => [$this->defaultIdentifier]])->first();
+        $record = $this->applyOptions($query, [
+            'select' => [$this->defaultIdentifier],
+            'skip_retrieval' => true,
+        ])->first();
 
         if ($record) {
             return $this->update($record[$this->defaultIdentifier], $values);
@@ -415,7 +444,7 @@ class Repository
 
     protected function isOptionsArray(array $data): bool
     {
-        $optionKeys = ['conditions', 'select', 'includes', 'with', 'order', 'sort', 'limit', 'offset', 'skip_cache'];
+        $optionKeys = ['conditions', 'select', 'includes', 'with', 'order', 'sort', 'limit', 'offset', 'skip_retrieval'];
 
         return (bool) array_intersect(array_keys($data), $optionKeys);
     }
@@ -423,6 +452,83 @@ class Repository
     protected function getClient(): Salesforce
     {
         return $this->client ?? app(Salesforce::class);
+    }
+
+    protected function captureStaleForInvalidation(array $lookup): ?array
+    {
+        if (! $this->cacheHandler || ! $this->hasNonDefaultIndexableFields()) {
+            return null;
+        }
+
+        return $this->first($lookup);
+    }
+
+    protected function invalidateAfterMutation(string $id, ?array $stale, array $payload): void
+    {
+        if (! $this->cacheHandler) {
+            return;
+        }
+
+        $this->cacheHandler->flushQueryCache();
+        $this->cacheHandler->forgetEntryByConditions($this->object, [$this->defaultIdentifier => $id]);
+
+        if (is_array($stale)) {
+            $this->forgetIndexableFields($stale, $payload);
+        } else {
+            $this->forgetPayloadIndexableFields($payload);
+        }
+    }
+
+    protected function forgetIndexableFields(array $record, array $payload = []): void
+    {
+        if (! $this->cacheHandler) {
+            return;
+        }
+
+        foreach ($this->indexableFields as $field) {
+            if ($field === $this->defaultIdentifier) {
+                continue;
+            }
+
+            $oldValue = $record[$field] ?? null;
+            $newValue = $payload[$field] ?? null;
+
+            foreach (array_unique(array_filter([$oldValue, $newValue], static fn ($v) => $v !== null), SORT_REGULAR) as $value) {
+                $this->cacheHandler->forgetEntryByConditions($this->object, [$field => $value]);
+            }
+        }
+    }
+
+    protected function forgetPayloadIndexableFields(array $payload): void
+    {
+        if (! $this->cacheHandler) {
+            return;
+        }
+
+        foreach ($this->indexableFields as $field) {
+            if ($field === $this->defaultIdentifier) {
+                continue;
+            }
+
+            $value = $payload[$field] ?? null;
+
+            if ($value === null) {
+                continue;
+            }
+
+            $this->cacheHandler->forgetEntryByConditions($this->object, [$field => $value]);
+        }
+    }
+
+    protected function hasNonDefaultIndexableFields(): bool
+    {
+        foreach ($this->indexableFields as $field) {
+            if ($field !== $this->defaultIdentifier) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected function filterNullDefaults(array $payload, array $attributes): array


### PR DESCRIPTION
* Split the schema cache (describe/picklist) into its own namespace so it survives data mutations; add flushSchemaCache and a --schema flag on the Artisan command.
* Drop negative entry caching and index entries by record identifiers rather than by the lookup's WHERE conditions, so a record cached by Email is correctly invalidated when updated by Id. Repositories now expose setIndexableFields and capture the pre-mutation record so stale lookups under non-default identifiers are evicted on update/upsert/delete.
* Force upsert/firstOrCreate/updateOrCreate lookups to skip the cache when deciding whether to create or update.
* Route describe/picklist through the new schema namespace with its own configurable TTL (SALESFORCE_SCHEMA_CACHE_DEFAULT_TTL).
* Introduce TokenManager + Laravel SalesforceTokenManager: derives TTL from expires_in with a 60s safety margin, serialises concurrent fetches with a cache lock, and transparently refreshes on HTTP 401 instead of binding the token into the Salesforce singleton.
* Replace the runningInConsole() auto-skip with the explicit SALESFORCE_SKIP_RETRIEVAL_DEFAULT config flag, and rename the skip_cache option to skip_retrieval everywhere.
* Rewrite Repository::count() through applyOptions so it honours skip_retrieval, select, and ordering like the other read methods.
* Stop pluck() mutating the underlying Query so the cache key matches the user's actual request.
* Refresh the README to document the three cache layers, the new env vars, the indexable-field API, and the schema flush command.