### PR TITLE
Add per-resource cache enable/disable toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,22 @@ attributes. `afterTransform()` runs after schema mapping and receives the
 transformed attributes. Both callbacks may also accept the current record and
 schema as later arguments when needed.
 
+## Resource-level cache toggle
+
+Salesforce resource classes cache query results by default. To disable caching
+for a single resource, set `cacheEnabled` to `false` (or call
+`setCacheEnabled(false)`):
+
+```php
+class LiveAccountResource extends \Oilstone\ApiSalesforceIntegration\Integrations\ApiResourceLoader\Resource
+{
+    protected bool $cacheEnabled = false;
+}
+```
+
+This applies only to repositories created through that resource; other
+resources continue using cache by default.
+
 ## Lookups
 
 Extend `Lookup` or `CachedLookup` to pull picklist values from Salesforce:

--- a/src/Integrations/ApiResourceLoader/Resource.php
+++ b/src/Integrations/ApiResourceLoader/Resource.php
@@ -29,6 +29,8 @@ class Resource extends BaseResource
 
     protected ?int $cacheTtl = null;
 
+    protected bool $cacheEnabled = true;
+
     protected ?QueryCacheHandler $cacheHandler = null;
 
     protected bool $cacheHandlerManuallySet = false;
@@ -83,7 +85,7 @@ class Resource extends BaseResource
             ->setDefaultIncludes(array_merge($this->includes(), $this->includes))
             ->setIdentifier($this->identifier);
 
-        $cacheHandler = $this->getCacheHandler();
+        $cacheHandler = $this->cacheEnabled ? $this->getCacheHandler() : null;
 
         if (method_exists($repository, 'setCacheHandler') && $cacheHandler) {
             $handler = clone $cacheHandler;
@@ -148,6 +150,19 @@ class Resource extends BaseResource
     public function setIdentifier(string $identifier): static
     {
         $this->identifier = $identifier;
+
+        return $this;
+    }
+
+
+    public function cacheEnabled(): bool
+    {
+        return $this->cacheEnabled;
+    }
+
+    public function setCacheEnabled(bool $enabled): static
+    {
+        $this->cacheEnabled = $enabled;
 
         return $this;
     }


### PR DESCRIPTION
### Motivation
- Allow individual API resource classes to opt out of query/result caching while keeping caching enabled by default for all resources.
- Provide a simple, explicit API on the resource to control whether repositories created from that resource attach the shared query cache handler.

### Description
- Added a `protected bool $cacheEnabled = true;` property to `Integrations/ApiResourceLoader/Resource` with accessor `cacheEnabled()` and mutator `setCacheEnabled(bool $enabled)` to allow per-resource toggling of caching.
- Updated `makeRepository()` to only resolve and attach a `QueryCacheHandler` when the resource's `cacheEnabled` is `true` by using ` $cacheHandler = $this->cacheEnabled ? $this->getCacheHandler() : null;`.
- Documented the new resource-level cache toggle in `README.md` with an example showing how to disable caching for a single resource.

### Testing
- Ran `php -l src/Integrations/ApiResourceLoader/Resource.php` and it reported no syntax errors.
- Ran `php -l src/Integrations/Laravel/Integrations/ApiResourceLoader/Resource.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ad4d9a988325a1224937b5c2ac7b)